### PR TITLE
ci: configure dependabot alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+    - package-ecosystem: "npm"
+      directory: "/"
+      schedule:
+        interval: "weekly"
+      labels:
+        - npm
+        - dependencies
+
+    - package-ecosystem: "bundler"
+      directory: "/"
+      schedule:
+        interval: "weekly"
+      labels:
+        - bundler
+        - dependencies
+
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+        interval: "weekly"
+      labels:
+        - github-actions
+        - dependencies

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,5 @@
+# Always validate the PR title AND all the commits
+titleAndCommits: true
+# Allows use of Merge commits (eg on github: "Merge branch 'master' into feature/ride-unicorns")
+# this is only relevant when using commitsOnly: true (or titleAndCommits: true)
+allowMergeCommits: true


### PR DESCRIPTION
Also adds rules to enforce [Conventional Commits](https://www.conventionalcommits.org) format.