### PR TITLE
BLAC-7 Configure MoreLikeThis functionality in Blacklight

### DIFF
--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -196,7 +196,9 @@
   </requestHandler>
 
   <requestHandler name="/mlt" class="solr.MoreLikeThisHandler">
-    <str name="mlt.fl">subject_tsimv</str>
+    <lst name="defaults">
+      <str name="mlt.fl">subject_tsimv</str>
+    </lst>
   </requestHandler>
 
   <requestHandler name="/replication" class="solr.ReplicationHandler" startup="lazy" />


### PR DESCRIPTION
Fix default configuration - Solr docs omitted the 'lst' element from the example configuration, without this caller needs to specify the mlt.fl parameter