### PR TITLE
Update readme to point to solr-trove for config

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The following tools provide linting, security and vulnerability checking of the 
 ## Containers
 
 ### Single-node Solr
+Prior to deploying a standalone Solr server (e.g. for local testing), copy any required Blacklight Solr config files from the [solr-trove](https://github.com/nla/solr-trove/tree/master/solr-config/src/main/resources/blacklight) repo.
 
 `./solr/docker-compose.yml` can be used to spin up a local Solr instance. This instance is configured to pre-create a core named `blacklight`.
 

--- a/solr/README.md
+++ b/solr/README.md
@@ -1,0 +1,7 @@
+# Solr configuration
+
+Whenever Blacklight is installed or rebuilt, the existing Solr config files will be replaced with the latest from blacklight-marc.
+
+Any persistent changes required to the Blacklight Solr configuration must be made in the [solr-trove](https://github.com/nla/solr-trove/tree/master/solr-config/src/main/resources/blacklight) repo.
+
+Prior to deploying a standalone Solr server (e.g. for local testing), copy any required Blacklight Solr config files from the [solr-trove](https://github.com/nla/solr-trove/tree/master/solr-config/src/main/resources/blacklight) repo.


### PR DESCRIPTION
Create a readme in the Solr dir
Add a note to main readme about copying solr config from solr-trove