### PR TITLE
feat: display document title and add styling [BLAC-10]

### DIFF
--- a/app/assets/stylesheets/_nla.scss
+++ b/app/assets/stylesheets/_nla.scss
@@ -1,0 +1,49 @@
+@import url('https://fonts.googleapis.com/css2?family=Frank+Ruhl+Libre:wght@300;400;500;700&family=Roboto+Condensed:wght@300;400;700&display=swap');
+
+html { font-size: 10px }
+
+// Colors
+:root {
+  --orange: #E03100;
+  --black: #000;
+  --white: #FFF;
+  --light-purple: #703996;
+  --light-yellow: #61B7F9;
+  --very-light-grey: rgb(244,245,246);
+  --grey-text: #46474A;
+  --dark-purple: rgb(5,7,91);
+  --blue: #1E4486;
+  --light-blue: #23AEFF;
+}
+
+$logo-image: image_url('nla_logo.svg') !default;
+
+$body-bg: var(--very-light-grey);
+$body-color: var(--grey-text);
+
+  // Typography
+$font-size-base: 1.8rem;
+$font-family-sans-serif: "Roboto condensed", sans-serif;
+
+// Headings
+$h1-font-size: 6.6rem;
+$h2-font-size: 4rem;
+$h3-font-size: 2.4rem;
+$h4-font-size: 2.2rem;
+$h5-font-size: 2.2rem;
+$h6-font-size: 1.6rem;
+$headings-font-family: "Frank Rhule Libre";
+$headings-font-weight: 900;
+$headings-line-height: 1.2;
+$headings-color: var(--dark-purple);
+
+// Links
+$link-color: #1E4486;
+$link-decoration: underline;
+$link-hover-color: var(--blue);
+$link-hover-decoration: none;
+
+body a:active {
+  color: var(--light-blue);
+  text-decoration: underline;
+}

--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -1,6 +1,5 @@
+@import 'nla';
 @import 'bootstrap';
-
-$logo-image: image_url('nla_logo.svg') !default;
 
 @import 'blacklight/blacklight';
 @import 'blacklight_marc';

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -127,8 +127,8 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
-    config.add_show_field "title_tsim", label: "Title"
-    config.add_show_field "title_vern_ssim", label: "Title"
+    # config.add_show_field "title_tsim", label: "Title"
+    # config.add_show_field "title_vern_ssim", label: "Title"
     config.add_show_field "subtitle_tsim", label: "Subtitle"
     config.add_show_field "subtitle_vern_ssim", label: "Subtitle"
     config.add_show_field "author_tsim", label: "Author"
@@ -145,7 +145,7 @@ class CatalogController < ApplicationController
     # scxxx
     # test display addition - TODO pull into extension module
     # config.add_show_field 'subject-nla_tsim', label: 'NLA Subject on single'
-    config.add_show_field "245abnps", label: "Full title", field: "id", helper_method: :from_marc
+    # config.add_show_field "245abnps", label: "Full title", field: "id", helper_method: :from_marc
     config.add_show_field "650ayzv", label: "Subjectus", field: "id", helper_method: :from_marc
     config.add_show_field "020aq", label: "ISBN", field: "id", helper_method: :from_marc
     config.add_show_field "880aq", label: "ISBN (880)", field: "id", helper_method: :from_marc


### PR DESCRIPTION
Removes the other "title" fields from the document record page. Also adds preliminary styling based on the [Blacklight Style Guide](https://ourweb.nla.gov.au/blacklight/).