### PR TITLE
feat: display Bib ID [BLAC-11]

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -129,6 +129,7 @@ class CatalogController < ApplicationController
     #   The ordering of the field names is the order of the display
     # config.add_show_field "title_tsim", label: "Title"
     # config.add_show_field "title_vern_ssim", label: "Title"
+    config.add_show_field label: "Bib ID", field: "id", accessor: :bib_id
     config.add_show_field "subtitle_tsim", label: "Subtitle"
     config.add_show_field "subtitle_vern_ssim", label: "Subtitle"
     config.add_show_field "author_tsim", label: "Author"

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -33,9 +33,13 @@ class SolrDocument
 
   ##
   # Get data from the full marc record contained in the solr document using a Traject spec.
-  def get_marc_derived_field(spec)
+  def get_marc_derived_field(spec, delimiter = ",")
     @marc_rec ||= to_marc
     extractor = Traject::MarcExtractor.cached(spec)
-    extractor.extract(@marc_rec)
+    extractor.extract(@marc_rec) * delimiter
+  end
+
+  def bib_id
+    get_marc_derived_field("001")
   end
 end


### PR DESCRIPTION
Adds an accessor to the `SolrDocument` model to retrieve the Bib ID from the MARC XML record.

It also modifies the `SolrDocument::get_marc_derived_field` to take a delimiter parameter since the results of the `Traject::MarcExtractor` extractor is an array. The delimiter is defaulted to add a comma (",") between the values.