### PR TITLE
BLAC-24 Add bib id to searchable fields

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -205,6 +205,11 @@ class CatalogController < ApplicationController
       }
     end
 
+    config.add_search_field("id") do |field|
+      field.label = "Bib Id"
+      field.qt = "search"
+    end
+
     # scxxx
     config.add_search_field("subject-nla") do |field|
       field.solr_parameters = {


### PR DESCRIPTION
Just finding it easer to grab bib Id than title so I get what I want for checking against VuFind entry in the BL UI. It's probably a bit of laziness on my part.