### PR TITLE
feat: convert URIs in notes into links [BLAC-19]

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -19,7 +19,7 @@ class CatalogController < ApplicationController
     # config.response_model = Blacklight::Solr::Response
     #
     ## Should the raw solr document endpoint (e.g. /catalog/:id/raw) be enabled
-    # config.raw_endpoint.enabled = false
+    config.raw_endpoint.enabled = true
 
     ## Default parameters to send to solr for all search-like requests. See also SearchBuilder#processed_parameters
     config.default_solr_params = {
@@ -128,12 +128,12 @@ class CatalogController < ApplicationController
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
     config.add_show_field "id", label: "Bib ID", field: "id"
-    config.add_show_field "author_tsim", label: "Author"
-    config.add_show_field "format", label: "Format"
-    config.add_show_field "online_access", label: "Online Access", accessor: :online_access, presenter: LinkedValuePresenter
+    config.add_show_field "author", field: "author_tsim", label: "Author"
+    config.add_show_field field: "format", label: "Format"
+    config.add_show_field "online_access", label: "Online Access", accessor: :online_access, presenter: AccessPresenter
     config.add_show_field "map_search", label: "Online Version", accessor: :map_search, presenter: MapSearchPresenter
-    config.add_show_field "copy_access", label: "Online Version", accessor: :copy_access, presenter: LinkedValuePresenter
-    config.add_show_field "related_access", label: "Related Online Resources", accessor: :related_access, presenter: LinkedValuePresenter
+    config.add_show_field "copy_access", label: "Online Version", accessor: :copy_access, presenter: AccessPresenter
+    config.add_show_field "related_access", label: "Related Online Resources", accessor: :related_access, presenter: AccessPresenter
     config.add_show_field label: "Description", field: "description", accessor: :description
     config.add_show_field "series", label: "Series", accessor: :series, presenter: ListPresenter
     config.add_show_field "notes", label: "Notes", accessor: :notes, presenter: NotesPresenter

--- a/app/presenters/access_presenter.rb
+++ b/app/presenters/access_presenter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class LinkedValuePresenter < Blacklight::FieldPresenter
+class AccessPresenter < Blacklight::FieldPresenter
   include ActionView::Helpers::OutputSafetyHelper
   include ActionView::Helpers::TagHelper
 

--- a/app/presenters/notes_presenter.rb
+++ b/app/presenters/notes_presenter.rb
@@ -7,6 +7,9 @@ class NotesPresenter < Blacklight::FieldPresenter
   attr_reader :view_context, :document, :field_config, :except_operations, :options
   delegate :key, :component, to: :field_config
 
+  # Original RegEx used by VuFind
+  # URL_REGEX = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=+$,\w]+@)?[A-Za-z0-9.-]+|(?:www.|[-;:&=+$,\w]+@)[A-Za-z0-9.-]+)((?:\/[+~%\/.[A-Za-z0-9_]-_]*)?\??(?:[-+=&;%@.\w_]*)#?(?:[\w\/.]*))?)/
+
   def render
     elements = []
 
@@ -30,7 +33,7 @@ class NotesPresenter < Blacklight::FieldPresenter
       view_context.content_tag(:ul) do
         safe_join(values.map do |value|
           view_context.content_tag(:li) do
-            value
+            link_urls(value)
           end
         end, "\n")
       end
@@ -39,5 +42,17 @@ class NotesPresenter < Blacklight::FieldPresenter
     end
 
     safe_join(elements, "\n")
+  end
+
+  def link_urls(value)
+    result = value
+
+    unless value.empty?
+      # rubocop:disable Rails/OutputSafety
+      result = value.gsub(URI::DEFAULT_PARSER.make_regexp, '<a href="\0">\0</a>').html_safe
+      # rubocop:enable Rails/OutputSafety
+    end
+
+    result
   end
 end


### PR DESCRIPTION
I've chosen to use the RegEx that is provided by the standard Ruby URI library instead of the chunky RegEx that was being used in VuFind (Which is broken BTW because it starts a range with a shorthand selector. Not allowed anymore in most recent RegEx parser including PCRE.) Can fallback to the original RegEx if it ends up missing some URIs.

Also renamed the `LinkedValuePresenter` to `AccessPresenter` since it's very much tailored to display ways to access the document.