### PR TITLE
fix: moves format above author on catalogue record page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -128,8 +128,8 @@ class CatalogController < ApplicationController
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
     config.add_show_field "id", label: "Bib ID", field: "id"
-    config.add_show_field "author", field: "author_tsim", label: "Author"
     config.add_show_field field: "format", label: "Format"
+    config.add_show_field "author", field: "author_tsim", label: "Author"
     config.add_show_field "online_access", label: "Online Access", accessor: :online_access, presenter: AccessPresenter
     config.add_show_field "map_search", label: "Online Version", accessor: :map_search, presenter: MapSearchPresenter
     config.add_show_field "copy_access", label: "Online Version", accessor: :copy_access, presenter: AccessPresenter


### PR DESCRIPTION
Fixes the order of the "author" and "format" fields on the catalogue record page.