### PR TITLE
fix: use Addressable::URI to parse URLs

### DIFF
--- a/app/models/search_link.rb
+++ b/app/models/search_link.rb
@@ -90,7 +90,7 @@ class SearchLink
   def extract_domain(url)
     result = ""
     unless url.empty?
-      host = URI.parse(url).host || ""
+      host = Addressable::URI.parse(url).host || ""
 
       if host.present?
         segments = host.split(".").reverse


### PR DESCRIPTION
Ruby's standard `URI` class isn't able to handle query strings very well. It was the `#` found in the query string of the URL that caused the error to be thrown.

I've changed the parser to `Addressable::URI` which is able to handle query strings and complicated URLs better.