### PR TITLE
feat: implements Blacklight Advanced Search plugin [BLAC-60]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,7 @@ gem "twitter-typeahead-rails", "0.11.1"
 gem "jquery-rails"
 gem "devise"
 gem "blacklight-marc", ">= 7.0.0.rc1", "< 9"
+gem "blacklight_advanced_search", "~> 7.0"
 
 gem "zk", "~> 1.10"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,9 @@ GEM
       marc-fastxmlwriter
       rails
       traject (~> 3.0)
+    blacklight_advanced_search (7.0.0)
+      blacklight (~> 7.0)
+      parslet
     bootsnap (1.13.0)
       msgpack (~> 1.2)
     bootstrap (4.6.1)
@@ -376,6 +379,7 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.1)
       ast (~> 2.4.1)
+    parslet (2.0.0)
     popper_js (1.16.0)
     public_suffix (4.0.7)
     puma (5.6.5)
@@ -595,6 +599,7 @@ DEPENDENCIES
   awesome_print
   blacklight (~> 7.29)
   blacklight-marc (>= 7.0.0.rc1, < 9)
+  blacklight_advanced_search (~> 7.0)
   bootsnap
   bootstrap (~> 4.0)
   brakeman

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -12,4 +12,7 @@
  *
  *= require_tree .
  *= require_self
- */
+ 
+ *= require 'blacklight_advanced_search'
+
+*/

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -3,10 +3,18 @@
 require "#{::Rails.root}/lib/blacklight/solr/cloud/repository"
 
 class CatalogController < ApplicationController
+  include BlacklightAdvancedSearch::Controller
   include Blacklight::Catalog
   include Blacklight::Marc::Catalog
 
   configure_blacklight do |config|
+    # default advanced config values
+    config.advanced_search ||= Blacklight::OpenStructWithHashAccess.new
+    # config.advanced_search[:qt] ||= 'advanced'
+    config.advanced_search[:url_key] ||= "advanced"
+    config.advanced_search[:query_parser] ||= "dismax"
+    config.advanced_search[:form_solr_parameters] ||= {}
+
     ## Class for sending and receiving requests from a search index
     if ENV["ZK_HOST"].present? && ENV["SOLR_COLLECTION"].present?
       config.repository_class = Blacklight::Solr::Cloud::Repository

--- a/app/controllers/saved_searches_controller.rb
+++ b/app/controllers/saved_searches_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class SavedSearchesController < ApplicationController
+  include Blacklight::SavedSearches
+
+  helper BlacklightAdvancedSearch::RenderConstraintsOverride
+end

--- a/app/controllers/search_history_controller.rb
+++ b/app/controllers/search_history_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class SearchHistoryController < ApplicationController
+  include Blacklight::SearchHistory
+
+  helper BlacklightAdvancedSearch::RenderConstraintsOverride
+end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -2,6 +2,8 @@
 
 class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
+  include BlacklightAdvancedSearch::AdvancedSearchBuilder
+  self.default_processor_chain += [:add_advanced_parse_q_to_solr, :add_advanced_search_to_solr]
 
   ##
   # @example Adding a new step to the processor chain

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,0 +1,13 @@
+<%= warn "#{__FILE__} is a deprecated partial." %>
+<%= render((blacklight_config&.view_config(document_index_view_type)&.search_bar_component || Blacklight::SearchBarComponent).new(
+      url: search_action_url,
+      advanced_search_url: search_action_url(action: 'advanced_search'),
+      params: search_state.params_for_search.except(:qt),
+      search_fields: Deprecation.silence(Blacklight::ConfigurationHelperBehavior) { search_fields },
+      autocomplete_path: search_action_path(action: :suggest))) %>
+
+
+
+<div>
+  <%= link_to 'More options', blacklight_advanced_search_engine.advanced_search_path(search_state.to_h), class: 'advanced_search btn btn-secondary'%>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   mount Blacklight::Engine => "/"
+  mount BlacklightAdvancedSearch::Engine => "/"
+
   concern :marc_viewable, Blacklight::Marc::Routes::MarcViewable.new
   root to: "catalog#index"
   concern :searchable, Blacklight::Routes::Searchable.new


### PR DESCRIPTION
Integration of this plugin implements boolean search in Blacklight's standard search box. It also make available advanced search options via the "More options" button.

This is a subtask of BLAC-55.