### PR TITLE
feat: implement reverse sort for Decades facet

### DIFF
--- a/app/components/decade_facet_list_component.rb
+++ b/app/components/decade_facet_list_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DecadeFacetComponent < Blacklight::FacetFieldListComponent
+class DecadeFacetListComponent < Blacklight::FacetFieldListComponent
   def render_facet_limit_list(paginator, facet_field, wrapping_element = :li)
     reverse_items = paginator.items.sort_by { |i| -i[:value] }.reverse
     paginator.instance_variable_set(:@all, reverse_items)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -105,13 +105,13 @@ class CatalogController < ApplicationController
     config.add_facet_field "subject_geo_ssim", label: "Region"
     config.add_facet_field "subject_era_ssim", label: "Era"
     config.add_facet_field "access_ssim", label: "Access"
-    # config.add_facet_field "decade_isim", label: "Decade", range: {
-    #   num_segments: 6,
-    #   assumed_boundaries: nil,
-    #   segments: true,
-    #   maxlength: 4
-    # }
-    config.add_facet_field "decade_isim", label: "Decade", component: DecadeFacetComponent
+    config.add_facet_field "decade_isim", label: "Decade Range", range: {
+      num_segments: 6,
+      assumed_boundaries: nil,
+      segments: true,
+      maxlength: 4
+    }
+    config.add_facet_field "decade_isim", label: "Decade", component: DecadeFacetListComponent
     config.add_facet_field "rights_category_ssim", label: "Rights Category", show: false
     config.add_facet_field "rights_full_name_ssim", label: "Rights Description", show: false
 


### PR DESCRIPTION
Took a stab at sorting the Decades facet in reverse order.

Feel free to modify as you wish. I've only commented out the Decades facet that uses the Range Limit plugin. I don't think you can have more than one defined for the same facet.