### PR TITLE
fix: force search bar to always use standard search [BLAC-83]

### DIFF
--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,12 +1,10 @@
 <%= warn "#{__FILE__} is a deprecated partial." %>
 <%= render((blacklight_config&.view_config(document_index_view_type)&.search_bar_component || Blacklight::SearchBarComponent).new(
-      url: search_action_url,
+      url: search_catalog_url,
       advanced_search_url: search_action_url(action: 'advanced_search'),
       params: search_state.params_for_search.except(:qt),
       search_fields: Deprecation.silence(Blacklight::ConfigurationHelperBehavior) { search_fields },
       autocomplete_path: search_action_path(action: :suggest))) %>
-
-
 
 <div>
   <%= link_to 'More options', blacklight_advanced_search_engine.advanced_search_path(search_state.to_h), class: 'advanced_search btn btn-secondary'%>

--- a/features/authentication.feature
+++ b/features/authentication.feature
@@ -3,7 +3,6 @@ Feature: Authentication
   As a user
   I should be able to log in and log out
 
-  @vcr
   Scenario: User Logs In
     Given I am a registered user
     And I visit the homepage
@@ -12,7 +11,6 @@ Feature: Authentication
     When I fill in the login form
     Then I should be logged in
 
-  @vcr
   Scenario: User Logs Out
     Given I am a registered user
     And I am logged in

--- a/features/standard_search.feature
+++ b/features/standard_search.feature
@@ -1,0 +1,13 @@
+Feature: Standard Search
+
+  Scenario: Search from search bar outside advanced search page
+    Given I visit the homepage
+    When I fill in the search bar form
+    And I click the Search button
+    Then I should be redirected to the search results page
+
+  Scenario: Search from search bar on advanced search page
+    Given I visit the advanced search page
+    When I fill in the search bar form
+    And I click the Search button
+    Then I should be redirected to the search results page

--- a/features/step_definitions/standard_search_steps.rb
+++ b/features/step_definitions/standard_search_steps.rb
@@ -1,0 +1,16 @@
+When("I fill in the search bar form") do
+  page.fill_in "q", with: "cats"
+end
+
+When("I click the Search button") do
+  find(:css, "#search").click
+end
+
+Then("I should be redirected to the search results page") do
+  expect(page).to have_content("Search Results")
+end
+
+Given("I visit the advanced search page") do
+  visit blacklight_advanced_search_engine.advanced_search_path
+  expect(page).to have_content("More Search Options")
+end


### PR DESCRIPTION
The partial that renders the search bar uses the index path for the current controller as the default value for the search box form. Because the advanced search page is served by the advanced search controller, the form is submitted to the advanced search controller instead of the catalog controller.

I've changed the partial to use the `search_catalog_url` to force the form to always submit the search box form to the catalog controller.