### PR TITLE
fix: drop search context for advanced search [BLAC-82]

### DIFF
--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -7,5 +7,5 @@
       autocomplete_path: search_action_path(action: :suggest))) %>
 
 <div>
-  <%= link_to 'More options', blacklight_advanced_search_engine.advanced_search_path, class: 'advanced_search btn btn-secondary'%>
+  <%= link_to 'Advanced search', blacklight_advanced_search_engine.advanced_search_path, class: 'advanced_search btn btn-secondary'%>
 </div>


### PR DESCRIPTION
This removes the search context when clicking on the Advanced Search button. Also renames "More options" to "Advanced Search".

The solution comes from Penn State's handling of a similar issue they were having with the Advanced Search plugin: https://github.com/psu-libraries/psulib_blacklight/issues/362