### PR TITLE
fix: excludes defType from spelling suggestions [BLAC-90]

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -24,10 +24,10 @@ class CatalogController < ApplicationController
     #
     ## Class for converting Blacklight's url parameters to into request parameters for the search index
     # config.search_builder_class = ::SearchBuilder
-    #
+
     ## Model that maps search index responses to the blacklight response model
-    # config.response_model = Blacklight::Solr::Response
-    #
+    config.response_model = NLA::Solr::Response
+
     ## Should the raw solr document endpoint (e.g. /catalog/:id/raw) be enabled
     config.raw_endpoint.enabled = true
 

--- a/app/models/nla/solr/response.rb
+++ b/app/models/nla/solr/response.rb
@@ -1,0 +1,7 @@
+module NLA
+  module Solr
+    class Response < Blacklight::Solr::Response
+      include Spelling
+    end
+  end
+end

--- a/app/models/nla/solr/response/spelling.rb
+++ b/app/models/nla/solr/response/spelling.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module NLA::Solr::Response::Spelling
+  EXCLUDED_TERMS = %w[dismax edismax lucene]
+
+  def spelling
+    @spelling ||= Base.new(self)
+  end
+
+  class Base
+    attr_reader :response
+
+    def initialize(response)
+      @response = response
+    end
+
+    # returns an array of spelling suggestion for specific query words,
+    # as provided in the solr response.  Only includes words with higher
+    # frequency of occurrence than word in original query.
+    # can't do a full query suggestion because we only get info for each word;
+    # combination of words may not have results.
+    # Thanks to Naomi Dushay!
+    def words
+      @words ||= begin
+        word_suggestions = []
+        spellcheck = response[:spellcheck]
+        if spellcheck && spellcheck[:suggestions]
+          suggestions = spellcheck[:suggestions]
+          unless suggestions.nil?
+            if suggestions.is_a?(Array)
+              # Before solr 6.5 suggestions is an array with the following format:
+              #    (query term)
+              #    (hash of term info and term suggestion)
+              #    ...
+              #    (query term)
+              #    (hash of term info and term suggestion)
+              #    'correctlySpelled'
+              #    true/false
+              #    collation
+              #    (suggestion for collation)
+              # We turn it into a hash here so that it is the same format as in solr 6.5 and later
+              suggestions = Hash[*suggestions].except("correctlySpelled", "collation")
+            end
+
+            # Exclude the defType term in case this is an advanced search query
+            suggestions = suggestions.except(*EXCLUDED_TERMS)
+
+            suggestions.each_value do |term_info|
+              # term_info is a hash:
+              #   numFound =>
+              #   startOffset =>
+              #   endOffset =>
+              #   origFreq =>
+              #   suggestion =>  [{ frequency =>, word => }] # for extended results
+              #   suggestion => ['word'] # for non-extended results
+              orig_freq = term_info["origFreq"]
+              word_suggestions << if term_info["suggestion"].first.is_a?(Hash)
+                term_info["suggestion"].map do |suggestion|
+                  suggestion["word"] if suggestion["freq"] > orig_freq
+                end
+              else
+                # only extended suggestions have frequency so we just return all suggestions
+                term_info["suggestion"]
+              end
+            end
+          end
+        end
+        word_suggestions.flatten.compact.uniq
+      end
+    end
+
+    def collation
+      # FIXME: DRY up with words
+      spellcheck = response[:spellcheck]
+      return unless spellcheck && spellcheck[:suggestions]
+
+      suggestions = spellcheck[:suggestions]
+
+      if suggestions.is_a?(Array) && suggestions.index("collation")
+        # solr < 5 response
+        suggestions[suggestions.index("collation") + 1]
+      elsif spellcheck.key?("collations")
+        # solr 5+ response
+        spellcheck["collations"].last if spellcheck.key?("collations")
+      end
+    end
+  end
+end

--- a/spec/files/spellcheck/advanced_response.json
+++ b/spec/files/spellcheck/advanced_response.json
@@ -1,0 +1,284 @@
+{
+  "responseHeader": {
+    "zkConnected": true,
+    "status": 0,
+    "QTime": 228,
+    "params": {
+      "facet.field": [
+        "format",
+        "{!ex=pub_date_ssim_single}pub_date_ssim",
+        "author_ssim",
+        "subject_ssim",
+        "language_ssim",
+        "austlang_ssim",
+        "lc_1letter_ssim",
+        "subject_geo_ssim",
+        "subject_era_ssim",
+        "access_ssim",
+        "decade_isim",
+        "rights_category_ssim",
+        "rights_full_name_ssim"
+      ],
+      "facet.pivot": "rights_category_ssim,rights_full_name_ssim",
+      "sort": "score desc, pub_date_si desc, title_si asc",
+      "rows": "10",
+      "f.austlang_ssim.facet.limit": "11",
+      "f.subject_ssim.facet.limit": "21",
+      "facet.query": [
+        "pub_date_ssim:[2017 TO *]",
+        "pub_date_ssim:[2012 TO *]",
+        "pub_date_ssim:[1997 TO *]"
+      ],
+      "f.language_ssim.facet.limit": "11",
+      "q": "_query_:\"{!dismax }5630205\"",
+      "defType": "lucene",
+      "stats": "true",
+      "facet": "true",
+      "wt": "json",
+      "f.author_ssim.facet.limit": "11",
+      "f.format.facet.limit": "21",
+      "stats.field": "decade_isim"
+    }
+  },
+  "response": {
+    "numFound": 1,
+    "start": 0,
+    "maxScore": 11.830234,
+    "numFoundExact": true,
+    "docs": [
+      {
+        "id": "5630205",
+        "call_number_tsim": [
+          "MC 2253 ED433582"
+        ],
+        "call_number_ssim": [
+          "MC 2253 ED433582"
+        ],
+        "language_ssim": [
+          "English"
+        ],
+        "subject_ssim": [
+          "Elementary Secondary Education",
+          "Foreign Countries",
+          "Parent Attitudes",
+          "Parent School Relationship",
+          "School Choice",
+          "School Demography",
+          "Single Sex Classes",
+          "Student Mobility",
+          "England"
+        ],
+        "all_subjects_tesim": [
+          "Elementary Secondary Education",
+          "Foreign Countries",
+          "Parent Attitudes",
+          "Parent School Relationship",
+          "School Choice",
+          "School Demography",
+          "Single Sex Classes",
+          "Student Mobility",
+          "England",
+          "Reports, Research",
+          "Speeches/Meeting Papers"
+        ],
+        "subject_tsimv": [
+          "Elementary Secondary Education",
+          "Foreign Countries",
+          "Parent Attitudes",
+          "Parent School Relationship",
+          "School Choice",
+          "School Demography",
+          "Single Sex Classes",
+          "Student Mobility",
+          "England"
+        ],
+        "genre_tesim": [
+          "Reports, Research",
+          "Speeches/Meeting Papers"
+        ],
+        "genre_ssim": [
+          "Reports, Research",
+          "Speeches/Meeting Papers"
+        ],
+        "title_tsim": [
+          "Single-Sex Teaching in Response to a Competitive Market [microform] : The Local Operation of a National Policy in England / Nigel Bennett"
+        ],
+        "title_ssim": [
+          "Single-Sex Teaching in Response to a Competitive Market [microform] : The Local Operation of a National Policy in England / Nigel Bennett"
+        ],
+        "title_vern_tsim": [
+          "Single-Sex Teaching in Response to a Competitive Market [microform] : The Local Operation of a National Policy in England / Nigel Bennett"
+        ],
+        "format": [
+          "Book",
+          "Microform"
+        ],
+        "author_tsim": [
+          "Bennett, Nigel"
+        ],
+        "author_ssim": [
+          "Bennett, Nigel"
+        ],
+        "pub_date_ssim": [
+          "1997"
+        ],
+        "collection_id_ssi": "(ericd)ED433582",
+        "date_lower_isi": 1997,
+        "decade_isim": [
+          1997
+        ],
+        "008_date_years_isim": [
+          1997
+        ],
+        "access_ssim": [
+          "Online",
+          "National Library (physical item)"
+        ],
+        "_version_": 1745772687496577024,
+        "timestamp": "2022-10-04T15:49:34.336Z",
+        "marc_ss": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><marc:collection xmlns:marc=\"http://www.loc.gov/MARC21/slim\"><marc:record><marc:leader>02793cam a22003732u 4500</marc:leader><marc:controlfield tag=\"001\">5630205</marc:controlfield><marc:controlfield tag=\"005\">20181017113442.0</marc:controlfield><marc:controlfield tag=\"007\">he u||024||||</marc:controlfield><marc:controlfield tag=\"008\">080220s1997    xxu ||| bt    ||| | eng d</marc:controlfield><marc:datafield tag=\"035\" ind1=\" \" ind2=\" \"><marc:subfield code=\"9\">(ericd)ED433582</marc:subfield></marc:datafield><marc:datafield tag=\"037\" ind1=\" \" ind2=\" \"><marc:subfield code=\"a\">ED433582</marc:subfield><marc:subfield code=\"b\">ERIC</marc:subfield></marc:datafield><marc:datafield tag=\"040\" ind1=\" \" ind2=\" \"><marc:subfield code=\"a\">ericd</marc:subfield><marc:subfield code=\"b\">eng</marc:subfield><marc:subfield code=\"c\">ericd</marc:subfield><marc:subfield code=\"d\">MvI</marc:subfield></marc:datafield><marc:datafield tag=\"091\" ind1=\" \" ind2=\" \"><marc:subfield code=\"a\">mfm</marc:subfield></marc:datafield><marc:datafield tag=\"100\" ind1=\"1\" ind2=\" \"><marc:subfield code=\"a\">Bennett, Nigel.</marc:subfield></marc:datafield><marc:datafield tag=\"245\" ind1=\"1\" ind2=\"0\"><marc:subfield code=\"a\">Single-Sex Teaching in Response to a Competitive Market</marc:subfield><marc:subfield code=\"h\">[microform] :</marc:subfield><marc:subfield code=\"b\">The Local Operation of a National Policy in England /</marc:subfield><marc:subfield code=\"c\">Nigel Bennett.</marc:subfield></marc:datafield><marc:datafield tag=\"260\" ind1=\" \" ind2=\" \"><marc:subfield code=\"a\">[Washington D.C.] :</marc:subfield><marc:subfield code=\"b\">Distributed by ERIC Clearinghouse,</marc:subfield><marc:subfield code=\"c\">1997.</marc:subfield></marc:datafield><marc:datafield tag=\"300\" ind1=\" \" ind2=\" \"><marc:subfield code=\"a\">26 p.</marc:subfield></marc:datafield><marc:datafield tag=\"500\" ind1=\" \" ind2=\" \"><marc:subfield code=\"a\">ERIC Note: Paper presented at the Annual Meeting of the American Educational Research Association (Chicago, IL, March 24-28, 1997).</marc:subfield><marc:subfield code=\"5\">ericd</marc:subfield></marc:datafield><marc:datafield tag=\"520\" ind1=\" \" ind2=\" \"><marc:subfield code=\"a\">This paper examines the local operation of educational provision in a small English town. It is based on 771 surveys received from parents whose children went to four mixed schools in the town in 1995. The survey asked about the family situation, parents' degree of choice in selecting a school for their children, and the influence of single-sex teaching in making that choice. The survey addressed six questions, such as To what extent were differences to be found among the four schools in the factors influencing the parents' choice of that school? and To what extent were the pattern of responses consistent between social classes? The findings show that the factors influencing parental choice are complicated. The differences among parents' priorities in choosing schools were not so much ideological as they were derived from a complex mix of practical concerns and a wish to help their children. The results show that the location of a pupil's home was unimportant in terms of the attitudes expressed in the survey. Single-sex teaching was clearly a positive reason for choice far more often than it was a negative reason for rejecting a school. Although many factors contributed to school choice, relatively few of them were widely shared. (Contains four references and nine tables.) (RJM)</marc:subfield></marc:datafield><marc:datafield tag=\"530\" ind1=\" \" ind2=\" \"><marc:subfield code=\"a\">May also be available online. Address as at 14/8/18: </marc:subfield><marc:subfield code=\"u\">https://eric.ed.gov/</marc:subfield></marc:datafield><marc:datafield tag=\"533\" ind1=\" \" ind2=\" \"><marc:subfield code=\"a\">Microfiche.</marc:subfield><marc:subfield code=\"b\">[Washington D.C.]:</marc:subfield><marc:subfield code=\"c\">ERIC Clearinghouse</marc:subfield><marc:subfield code=\"e\">microfiches : positive.</marc:subfield></marc:datafield><marc:datafield tag=\"650\" ind1=\"0\" ind2=\"7\"><marc:subfield code=\"a\">Elementary Secondary Education.</marc:subfield><marc:subfield code=\"2\">ericd</marc:subfield></marc:datafield><marc:datafield tag=\"650\" ind1=\"0\" ind2=\"7\"><marc:subfield code=\"a\">Foreign Countries.</marc:subfield><marc:subfield code=\"2\">ericd</marc:subfield></marc:datafield><marc:datafield tag=\"650\" ind1=\"1\" ind2=\"7\"><marc:subfield code=\"a\">Parent Attitudes.</marc:subfield><marc:subfield code=\"2\">ericd</marc:subfield></marc:datafield><marc:datafield tag=\"650\" ind1=\"0\" ind2=\"7\"><marc:subfield code=\"a\">Parent School Relationship.</marc:subfield><marc:subfield code=\"2\">ericd</marc:subfield></marc:datafield><marc:datafield tag=\"650\" ind1=\"1\" ind2=\"7\"><marc:subfield code=\"a\">School Choice.</marc:subfield><marc:subfield code=\"2\">ericd</marc:subfield></marc:datafield><marc:datafield tag=\"650\" ind1=\"0\" ind2=\"7\"><marc:subfield code=\"a\">School Demography.</marc:subfield><marc:subfield code=\"2\">ericd</marc:subfield></marc:datafield><marc:datafield tag=\"650\" ind1=\"1\" ind2=\"7\"><marc:subfield code=\"a\">Single Sex Classes.</marc:subfield><marc:subfield code=\"2\">ericd</marc:subfield></marc:datafield><marc:datafield tag=\"650\" ind1=\"0\" ind2=\"7\"><marc:subfield code=\"a\">Student Mobility.</marc:subfield><marc:subfield code=\"2\">ericd</marc:subfield></marc:datafield><marc:datafield tag=\"653\" ind1=\"1\" ind2=\" \"><marc:subfield code=\"a\">England</marc:subfield></marc:datafield><marc:datafield tag=\"655\" ind1=\" \" ind2=\"7\"><marc:subfield code=\"a\">Reports, Research.</marc:subfield><marc:subfield code=\"2\">ericd</marc:subfield></marc:datafield><marc:datafield tag=\"655\" ind1=\" \" ind2=\"7\"><marc:subfield code=\"a\">Speeches/Meeting Papers.</marc:subfield><marc:subfield code=\"2\">ericd</marc:subfield></marc:datafield><marc:datafield tag=\"856\" ind1=\"4\" ind2=\"1\"><marc:subfield code=\"u\">https://eric.ed.gov/?id=ED433582</marc:subfield></marc:datafield><marc:datafield tag=\"984\" ind1=\" \" ind2=\" \"><marc:subfield code=\"a\">ANL</marc:subfield><marc:subfield code=\"c\">mc 2253 ED433582</marc:subfield><marc:subfield code=\"d\">77000000433629</marc:subfield></marc:datafield></marc:record></marc:collection>\n",
+        "score": 11.830234
+      }
+    ]
+  },
+  "facet_counts": {
+    "facet_queries": {
+      "pub_date_ssim:[1997 TO *]": 1
+    },
+    "facet_fields": {
+      "format": [
+        "Book",
+        1,
+        "Microform",
+        1
+      ],
+      "pub_date_ssim": [
+        "1997",
+        1
+      ],
+      "author_ssim": [
+        "Bennett, Nigel",
+        1
+      ],
+      "subject_ssim": [
+        "Elementary Secondary Education",
+        1,
+        "England",
+        1,
+        "Foreign Countries",
+        1,
+        "Parent Attitudes",
+        1,
+        "Parent School Relationship",
+        1,
+        "School Choice",
+        1,
+        "School Demography",
+        1,
+        "Single Sex Classes",
+        1,
+        "Student Mobility",
+        1
+      ],
+      "language_ssim": [
+        "English",
+        1
+      ],
+      "austlang_ssim": [
+
+      ],
+      "lc_1letter_ssim": [
+
+      ],
+      "subject_geo_ssim": [
+
+      ],
+      "subject_era_ssim": [
+
+      ],
+      "access_ssim": [
+        "National Library (physical item)",
+        1,
+        "Online",
+        1
+      ],
+      "decade_isim": [
+        "1997",
+        1
+      ],
+      "rights_category_ssim": [
+
+      ],
+      "rights_full_name_ssim": [
+
+      ]
+    },
+    "facet_ranges": {
+
+    },
+    "facet_intervals": {
+
+    },
+    "facet_heatmaps": {
+
+    },
+    "facet_pivot": {
+      "rights_category_ssim,rights_full_name_ssim": [
+
+      ]
+    }
+  },
+  "stats": {
+    "stats_fields": {
+      "decade_isim": {
+        "min": 1997.0,
+        "max": 1997.0,
+        "count": 1,
+        "missing": 0,
+        "sum": 1997.0,
+        "sumOfSquares": 3988009.0,
+        "mean": 1997.0,
+        "stddev": 0.0
+      }
+    }
+  },
+  "spellcheck": {
+    "suggestions": [
+      "dismax",
+      {
+        "numFound": 3,
+        "startOffset": 11,
+        "endOffset": 17,
+        "origFreq": 0,
+        "suggestion": [
+          {
+            "word": "distant",
+            "freq": 84
+          },
+          {
+            "word": "diseases",
+            "freq": 1133
+          },
+          {
+            "word": "discus",
+            "freq": 5
+          }
+        ]
+      },
+      "5630205",
+      {
+        "numFound": 1,
+        "startOffset": 19,
+        "endOffset": 26,
+        "origFreq": 0,
+        "suggestion": [
+          {
+            "word": "4130260529",
+            "freq": 1
+          }
+        ]
+      }
+    ],
+    "correctlySpelled": true
+  }
+}

--- a/spec/files/spellcheck/standard_response.json
+++ b/spec/files/spellcheck/standard_response.json
@@ -1,0 +1,263 @@
+{
+  "responseHeader": {
+    "zkConnected": true,
+    "status": 0,
+    "QTime": 219,
+    "params": {
+      "facet.field": [
+        "format",
+        "{!ex=pub_date_ssim_single}pub_date_ssim",
+        "author_ssim",
+        "subject_ssim",
+        "language_ssim",
+        "austlang_ssim",
+        "lc_1letter_ssim",
+        "subject_geo_ssim",
+        "subject_era_ssim",
+        "access_ssim",
+        "decade_isim",
+        "rights_category_ssim",
+        "rights_full_name_ssim"
+      ],
+      "facet.pivot": "rights_category_ssim,rights_full_name_ssim",
+      "sort": "score desc, pub_date_si desc, title_si asc",
+      "rows": "10",
+      "f.austlang_ssim.facet.limit": "11",
+      "f.subject_ssim.facet.limit": "21",
+      "facet.query": [
+        "pub_date_ssim:[2017 TO *]",
+        "pub_date_ssim:[2012 TO *]",
+        "pub_date_ssim:[1997 TO *]"
+      ],
+      "f.language_ssim.facet.limit": "11",
+      "q": "5630205",
+      "defType": "dismax",
+      "stats": "true",
+      "facet": "true",
+      "wt": "json",
+      "f.author_ssim.facet.limit": "11",
+      "f.format.facet.limit": "21",
+      "stats.field": "decade_isim"
+    }
+  },
+  "response": {
+    "numFound": 1,
+    "start": 0,
+    "maxScore": 11.830234,
+    "numFoundExact": true,
+    "docs": [
+      {
+        "id": "5630205",
+        "call_number_tsim": [
+          "MC 2253 ED433582"
+        ],
+        "call_number_ssim": [
+          "MC 2253 ED433582"
+        ],
+        "language_ssim": [
+          "English"
+        ],
+        "subject_ssim": [
+          "Elementary Secondary Education",
+          "Foreign Countries",
+          "Parent Attitudes",
+          "Parent School Relationship",
+          "School Choice",
+          "School Demography",
+          "Single Sex Classes",
+          "Student Mobility",
+          "England"
+        ],
+        "all_subjects_tesim": [
+          "Elementary Secondary Education",
+          "Foreign Countries",
+          "Parent Attitudes",
+          "Parent School Relationship",
+          "School Choice",
+          "School Demography",
+          "Single Sex Classes",
+          "Student Mobility",
+          "England",
+          "Reports, Research",
+          "Speeches/Meeting Papers"
+        ],
+        "subject_tsimv": [
+          "Elementary Secondary Education",
+          "Foreign Countries",
+          "Parent Attitudes",
+          "Parent School Relationship",
+          "School Choice",
+          "School Demography",
+          "Single Sex Classes",
+          "Student Mobility",
+          "England"
+        ],
+        "genre_tesim": [
+          "Reports, Research",
+          "Speeches/Meeting Papers"
+        ],
+        "genre_ssim": [
+          "Reports, Research",
+          "Speeches/Meeting Papers"
+        ],
+        "title_tsim": [
+          "Single-Sex Teaching in Response to a Competitive Market [microform] : The Local Operation of a National Policy in England / Nigel Bennett"
+        ],
+        "title_ssim": [
+          "Single-Sex Teaching in Response to a Competitive Market [microform] : The Local Operation of a National Policy in England / Nigel Bennett"
+        ],
+        "title_vern_tsim": [
+          "Single-Sex Teaching in Response to a Competitive Market [microform] : The Local Operation of a National Policy in England / Nigel Bennett"
+        ],
+        "format": [
+          "Book",
+          "Microform"
+        ],
+        "author_tsim": [
+          "Bennett, Nigel"
+        ],
+        "author_ssim": [
+          "Bennett, Nigel"
+        ],
+        "pub_date_ssim": [
+          "1997"
+        ],
+        "collection_id_ssi": "(ericd)ED433582",
+        "date_lower_isi": 1997,
+        "decade_isim": [
+          1997
+        ],
+        "008_date_years_isim": [
+          1997
+        ],
+        "access_ssim": [
+          "Online",
+          "National Library (physical item)"
+        ],
+        "_version_": 1745772687496577024,
+        "timestamp": "2022-10-04T15:49:34.336Z",
+        "marc_ss": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><marc:collection xmlns:marc=\"http://www.loc.gov/MARC21/slim\"><marc:record><marc:leader>02793cam a22003732u 4500</marc:leader><marc:controlfield tag=\"001\">5630205</marc:controlfield><marc:controlfield tag=\"005\">20181017113442.0</marc:controlfield><marc:controlfield tag=\"007\">he u||024||||</marc:controlfield><marc:controlfield tag=\"008\">080220s1997    xxu ||| bt    ||| | eng d</marc:controlfield><marc:datafield tag=\"035\" ind1=\" \" ind2=\" \"><marc:subfield code=\"9\">(ericd)ED433582</marc:subfield></marc:datafield><marc:datafield tag=\"037\" ind1=\" \" ind2=\" \"><marc:subfield code=\"a\">ED433582</marc:subfield><marc:subfield code=\"b\">ERIC</marc:subfield></marc:datafield><marc:datafield tag=\"040\" ind1=\" \" ind2=\" \"><marc:subfield code=\"a\">ericd</marc:subfield><marc:subfield code=\"b\">eng</marc:subfield><marc:subfield code=\"c\">ericd</marc:subfield><marc:subfield code=\"d\">MvI</marc:subfield></marc:datafield><marc:datafield tag=\"091\" ind1=\" \" ind2=\" \"><marc:subfield code=\"a\">mfm</marc:subfield></marc:datafield><marc:datafield tag=\"100\" ind1=\"1\" ind2=\" \"><marc:subfield code=\"a\">Bennett, Nigel.</marc:subfield></marc:datafield><marc:datafield tag=\"245\" ind1=\"1\" ind2=\"0\"><marc:subfield code=\"a\">Single-Sex Teaching in Response to a Competitive Market</marc:subfield><marc:subfield code=\"h\">[microform] :</marc:subfield><marc:subfield code=\"b\">The Local Operation of a National Policy in England /</marc:subfield><marc:subfield code=\"c\">Nigel Bennett.</marc:subfield></marc:datafield><marc:datafield tag=\"260\" ind1=\" \" ind2=\" \"><marc:subfield code=\"a\">[Washington D.C.] :</marc:subfield><marc:subfield code=\"b\">Distributed by ERIC Clearinghouse,</marc:subfield><marc:subfield code=\"c\">1997.</marc:subfield></marc:datafield><marc:datafield tag=\"300\" ind1=\" \" ind2=\" \"><marc:subfield code=\"a\">26 p.</marc:subfield></marc:datafield><marc:datafield tag=\"500\" ind1=\" \" ind2=\" \"><marc:subfield code=\"a\">ERIC Note: Paper presented at the Annual Meeting of the American Educational Research Association (Chicago, IL, March 24-28, 1997).</marc:subfield><marc:subfield code=\"5\">ericd</marc:subfield></marc:datafield><marc:datafield tag=\"520\" ind1=\" \" ind2=\" \"><marc:subfield code=\"a\">This paper examines the local operation of educational provision in a small English town. It is based on 771 surveys received from parents whose children went to four mixed schools in the town in 1995. The survey asked about the family situation, parents' degree of choice in selecting a school for their children, and the influence of single-sex teaching in making that choice. The survey addressed six questions, such as To what extent were differences to be found among the four schools in the factors influencing the parents' choice of that school? and To what extent were the pattern of responses consistent between social classes? The findings show that the factors influencing parental choice are complicated. The differences among parents' priorities in choosing schools were not so much ideological as they were derived from a complex mix of practical concerns and a wish to help their children. The results show that the location of a pupil's home was unimportant in terms of the attitudes expressed in the survey. Single-sex teaching was clearly a positive reason for choice far more often than it was a negative reason for rejecting a school. Although many factors contributed to school choice, relatively few of them were widely shared. (Contains four references and nine tables.) (RJM)</marc:subfield></marc:datafield><marc:datafield tag=\"530\" ind1=\" \" ind2=\" \"><marc:subfield code=\"a\">May also be available online. Address as at 14/8/18: </marc:subfield><marc:subfield code=\"u\">https://eric.ed.gov/</marc:subfield></marc:datafield><marc:datafield tag=\"533\" ind1=\" \" ind2=\" \"><marc:subfield code=\"a\">Microfiche.</marc:subfield><marc:subfield code=\"b\">[Washington D.C.]:</marc:subfield><marc:subfield code=\"c\">ERIC Clearinghouse</marc:subfield><marc:subfield code=\"e\">microfiches : positive.</marc:subfield></marc:datafield><marc:datafield tag=\"650\" ind1=\"0\" ind2=\"7\"><marc:subfield code=\"a\">Elementary Secondary Education.</marc:subfield><marc:subfield code=\"2\">ericd</marc:subfield></marc:datafield><marc:datafield tag=\"650\" ind1=\"0\" ind2=\"7\"><marc:subfield code=\"a\">Foreign Countries.</marc:subfield><marc:subfield code=\"2\">ericd</marc:subfield></marc:datafield><marc:datafield tag=\"650\" ind1=\"1\" ind2=\"7\"><marc:subfield code=\"a\">Parent Attitudes.</marc:subfield><marc:subfield code=\"2\">ericd</marc:subfield></marc:datafield><marc:datafield tag=\"650\" ind1=\"0\" ind2=\"7\"><marc:subfield code=\"a\">Parent School Relationship.</marc:subfield><marc:subfield code=\"2\">ericd</marc:subfield></marc:datafield><marc:datafield tag=\"650\" ind1=\"1\" ind2=\"7\"><marc:subfield code=\"a\">School Choice.</marc:subfield><marc:subfield code=\"2\">ericd</marc:subfield></marc:datafield><marc:datafield tag=\"650\" ind1=\"0\" ind2=\"7\"><marc:subfield code=\"a\">School Demography.</marc:subfield><marc:subfield code=\"2\">ericd</marc:subfield></marc:datafield><marc:datafield tag=\"650\" ind1=\"1\" ind2=\"7\"><marc:subfield code=\"a\">Single Sex Classes.</marc:subfield><marc:subfield code=\"2\">ericd</marc:subfield></marc:datafield><marc:datafield tag=\"650\" ind1=\"0\" ind2=\"7\"><marc:subfield code=\"a\">Student Mobility.</marc:subfield><marc:subfield code=\"2\">ericd</marc:subfield></marc:datafield><marc:datafield tag=\"653\" ind1=\"1\" ind2=\" \"><marc:subfield code=\"a\">England</marc:subfield></marc:datafield><marc:datafield tag=\"655\" ind1=\" \" ind2=\"7\"><marc:subfield code=\"a\">Reports, Research.</marc:subfield><marc:subfield code=\"2\">ericd</marc:subfield></marc:datafield><marc:datafield tag=\"655\" ind1=\" \" ind2=\"7\"><marc:subfield code=\"a\">Speeches/Meeting Papers.</marc:subfield><marc:subfield code=\"2\">ericd</marc:subfield></marc:datafield><marc:datafield tag=\"856\" ind1=\"4\" ind2=\"1\"><marc:subfield code=\"u\">https://eric.ed.gov/?id=ED433582</marc:subfield></marc:datafield><marc:datafield tag=\"984\" ind1=\" \" ind2=\" \"><marc:subfield code=\"a\">ANL</marc:subfield><marc:subfield code=\"c\">mc 2253 ED433582</marc:subfield><marc:subfield code=\"d\">77000000433629</marc:subfield></marc:datafield></marc:record></marc:collection>\n",
+        "score": 11.830234
+      }
+    ]
+  },
+  "facet_counts": {
+    "facet_queries": {
+      "pub_date_ssim:[1997 TO *]": 1
+    },
+    "facet_fields": {
+      "format": [
+        "Book",
+        1,
+        "Microform",
+        1
+      ],
+      "pub_date_ssim": [
+        "1997",
+        1
+      ],
+      "author_ssim": [
+        "Bennett, Nigel",
+        1
+      ],
+      "subject_ssim": [
+        "Elementary Secondary Education",
+        1,
+        "England",
+        1,
+        "Foreign Countries",
+        1,
+        "Parent Attitudes",
+        1,
+        "Parent School Relationship",
+        1,
+        "School Choice",
+        1,
+        "School Demography",
+        1,
+        "Single Sex Classes",
+        1,
+        "Student Mobility",
+        1
+      ],
+      "language_ssim": [
+        "English",
+        1
+      ],
+      "austlang_ssim": [
+
+      ],
+      "lc_1letter_ssim": [
+
+      ],
+      "subject_geo_ssim": [
+
+      ],
+      "subject_era_ssim": [
+
+      ],
+      "access_ssim": [
+        "National Library (physical item)",
+        1,
+        "Online",
+        1
+      ],
+      "decade_isim": [
+        "1997",
+        1
+      ],
+      "rights_category_ssim": [
+
+      ],
+      "rights_full_name_ssim": [
+
+      ]
+    },
+    "facet_ranges": {
+
+    },
+    "facet_intervals": {
+
+    },
+    "facet_heatmaps": {
+
+    },
+    "facet_pivot": {
+      "rights_category_ssim,rights_full_name_ssim": [
+
+      ]
+    }
+  },
+  "stats": {
+    "stats_fields": {
+      "decade_isim": {
+        "min": 1997.0,
+        "max": 1997.0,
+        "count": 1,
+        "missing": 0,
+        "sum": 1997.0,
+        "sumOfSquares": 3988009.0,
+        "mean": 1997.0,
+        "stddev": 0.0
+      }
+    }
+  },
+  "spellcheck": {
+    "suggestions": [
+      "5630205",
+      {
+        "numFound": 1,
+        "startOffset": 0,
+        "endOffset": 7,
+        "origFreq": 0,
+        "suggestion": [
+          {
+            "word": "4130260529",
+            "freq": 1
+          }
+        ]
+      }
+    ],
+    "correctlySpelled": true
+  }
+}

--- a/spec/models/nla/solr/response_spec.rb
+++ b/spec/models/nla/solr/response_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NLA::Solr::Response do
+  let(:config) { Blacklight::Configuration.new }
+
+  context "when a standard search is performed" do
+    subject(:r) { described_class.new(standard_response, {}) }
+
+    it "provides spelling suggestions for regular search" do
+      expect(r.spelling.words).to include("4130260529")
+    end
+  end
+
+  context "when an advanced search is performed" do
+    subject(:r) { described_class.new(advanced_response, {}) }
+
+    it "provides spelling suggestions for advanced search" do
+      expect(r.spelling.words).to include("4130260529")
+    end
+
+    it "excludes defType terms from spelling suggestions" do
+      expect(r.spelling.words).not_to include("dismax")
+    end
+  end
+
+  def advanced_response
+    JSON.parse(IO.read("spec/files/spellcheck/advanced_response.json"))
+  end
+
+  def standard_response
+    JSON.parse(IO.read("spec/files/spellcheck/standard_response.json"))
+  end
+end


### PR DESCRIPTION
This creates a custom `Response` model and `Spelling` mixin to exclude the Solr "defType" from the list of spelling suggestions that are displayed to the UI.