### PR TITLE
chore: refactors 'fair dealing' link to plain text [BLAC-92]

### DIFF
--- a/app/components/copyright_info/_message1_1.html.erb
+++ b/app/components/copyright_info/_message1_1.html.erb
@@ -2,4 +2,4 @@
 
 <p>You may copy under some circumstances, for example you may copy a portion for research or study.
   Order a copy through <%= copies_direct_link %> to the extent allowed under
-  <%= fair_dealing_link %>. <%= rights_contact_us_link %> for further information about copying.</p>
+  fair dealing. <%= rights_contact_us_link %> for further information about copying.</p>

--- a/app/components/copyright_info/_message1_3.html.erb
+++ b/app/components/copyright_info/_message1_3.html.erb
@@ -2,4 +2,4 @@
 
 <p>You may have full rights to copy, or may be able to copy only under some circumstances, for example a portion for
   research or study. Order a copy through <%= copies_direct_link %>&nbsp;to the extent allowed under
-  <%= fair_dealing_link %>. <%= rights_contact_us_link %> for further information about copying.</p>
+  fair dealing. <%= rights_contact_us_link %> for further information about copying.</p>

--- a/app/components/copyright_info/_message2_2.html.erb
+++ b/app/components/copyright_info/_message2_2.html.erb
@@ -2,4 +2,4 @@
 
 <p>Copyright varies with publication date of each issue. You may have full rights to copy, or may be able to copy only
   under some circumstances, for example a portion for research or study. Order a copy through <%= copies_direct_link %>&nbsp;to
-  the extent allowed under <%= fair_dealing_link %>. <%= rights_contact_us_link %> for further information about copying.</p>
+  the extent allowed under fair dealing. <%= rights_contact_us_link %> for further information about copying.</p>

--- a/app/components/copyright_info_component.rb
+++ b/app/components/copyright_info_component.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CopyrightInfoComponent < ViewComponent::Base
+  include CopyrightHelper
+
   def initialize(copyright:)
     @copyright = copyright
   end

--- a/app/helpers/copyright_helper.rb
+++ b/app/helpers/copyright_helper.rb
@@ -1,8 +1,4 @@
 module CopyrightHelper
-  def fair_dealing_link
-    link_to "fair dealing", ENV["COPYRIGHT_FAIR_DEALING_URL"]
-  end
-
   def rights_contact_us_link
     link_to "Contact us", ENV["COPYRIGHT_CONTACT_URL"]
   end

--- a/spec/components/copyright_info_component_spec.rb
+++ b/spec/components/copyright_info_component_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe CopyrightInfoComponent, type: :component do
 
   before do
     stub_const("ENV", ENV.to_hash.merge("COPYRIGHT_SERVICE_URL" => "https://example.com/copyright/"))
-    stub_const("ENV", ENV.to_hash.merge("COPYRIGHT_FAIR_DEALING_URL" => "https://example.com/fair_dealing"))
     stub_const("ENV", ENV.to_hash.merge("COPYRIGHT_CONTACT_URL" => "https://example.com/contact-us"))
 
     stub_request(:get, "https://example.com/copyright/")
@@ -30,6 +29,7 @@ RSpec.describe CopyrightInfoComponent, type: :component do
     render_inline(described_class.new(copyright: copyright))
 
     expect(page.text).to include "Contact us"
+    expect(page).to have_xpath("//a[@href='https://example.com/contact-us']")
   end
 
   context "when status context message is 1.1" do
@@ -55,12 +55,14 @@ RSpec.describe CopyrightInfoComponent, type: :component do
       render_inline(described_class.new(copyright: copyright))
 
       expect(page.text).to include "Copies Direct"
+      expect(page).to have_xpath("//a[@href='javascript:;']")
     end
 
-    it "renders the 'fair dealing' link" do
+    it "renders the 'fair dealing' as text" do
       render_inline(described_class.new(copyright: copyright))
 
       expect(page.text).to include "fair dealing"
+      expect(page).not_to have_xpath("//a[text()='fair dealing']")
     end
   end
 
@@ -87,6 +89,7 @@ RSpec.describe CopyrightInfoComponent, type: :component do
       render_inline(described_class.new(copyright: copyright))
 
       expect(page.text).to include "Copies Direct"
+      expect(page).to have_xpath("//a[@href='javascript:;']")
     end
   end
 
@@ -113,12 +116,14 @@ RSpec.describe CopyrightInfoComponent, type: :component do
       render_inline(described_class.new(copyright: copyright))
 
       expect(page.text).to include "Copies Direct"
+      expect(page).to have_xpath("//a[@href='javascript:;']")
     end
 
-    it "renders the 'fair dealing' link" do
+    it "renders the 'fair dealing' as text" do
       render_inline(described_class.new(copyright: copyright))
 
       expect(page.text).to include "fair dealing"
+      expect(page).not_to have_xpath("//a[text()='fair dealing']")
     end
   end
 
@@ -145,6 +150,7 @@ RSpec.describe CopyrightInfoComponent, type: :component do
       render_inline(described_class.new(copyright: copyright))
 
       expect(page.text).to include "Copies Direct"
+      expect(page).to have_xpath("//a[@href='javascript:;']")
     end
   end
 
@@ -171,12 +177,14 @@ RSpec.describe CopyrightInfoComponent, type: :component do
       render_inline(described_class.new(copyright: copyright))
 
       expect(page.text).to include "Copies Direct"
+      expect(page).to have_xpath("//a[@href='javascript:;']")
     end
 
-    it "renders the 'fair dealing' link" do
+    it "renders the 'fair dealing' as text" do
       render_inline(described_class.new(copyright: copyright))
 
       expect(page.text).to include "fair dealing"
+      expect(page).not_to have_xpath("//a[text()='fair dealing']")
     end
   end
 
@@ -203,6 +211,7 @@ RSpec.describe CopyrightInfoComponent, type: :component do
       render_inline(described_class.new(copyright: copyright))
 
       expect(page.text).not_to include "Copies Direct"
+      expect(page).not_to have_xpath("//a[@href='javascript:;']")
     end
   end
 
@@ -229,6 +238,7 @@ RSpec.describe CopyrightInfoComponent, type: :component do
       render_inline(described_class.new(copyright: copyright))
 
       expect(page.text).not_to include "Copies Direct"
+      expect(page).not_to have_xpath("//a[@href='javascript:;']")
     end
   end
 
@@ -255,6 +265,7 @@ RSpec.describe CopyrightInfoComponent, type: :component do
       render_inline(described_class.new(copyright: copyright))
 
       expect(page.text).to include "Copies Direct"
+      expect(page).to have_xpath("//a[@href='javascript:;']")
     end
   end
 
@@ -281,6 +292,7 @@ RSpec.describe CopyrightInfoComponent, type: :component do
       render_inline(described_class.new(copyright: copyright))
 
       expect(page.text).not_to include "Copies Direct"
+      expect(page).not_to have_xpath("//a[@href='javascript:;']")
     end
   end
 
@@ -307,6 +319,7 @@ RSpec.describe CopyrightInfoComponent, type: :component do
       render_inline(described_class.new(copyright: copyright))
 
       expect(page.text).not_to include "Copies Direct"
+      expect(page).not_to have_xpath("//a[@href='javascript:;']")
     end
   end
 
@@ -333,6 +346,7 @@ RSpec.describe CopyrightInfoComponent, type: :component do
       render_inline(described_class.new(copyright: copyright))
 
       expect(page.text).to include "Copies Direct"
+      expect(page).to have_xpath("//a[@href='javascript:;']")
     end
   end
 

--- a/spec/helpers/copyright_helper_spec.rb
+++ b/spec/helpers/copyright_helper_spec.rb
@@ -8,12 +8,8 @@ RSpec.describe CopyrightHelper do
   let(:config) { Blacklight::Configuration.new.view_config(:show) }
 
   describe "#fair_dealing_link" do
-    subject(:link) { helper.fair_dealing_link }
-
-    it "generates a link using the environment variable value" do
-      stub_const("ENV", ENV.to_hash.merge("COPYRIGHT_FAIR_DEALING_URL" => "https://example.com/fair_dealing"))
-
-      expect(link).to include '<a href="https://example.com/fair_dealing">fair dealing</a>'
+    it "raises an error" do
+      expect { helper.fair_dealing_link }.to raise_error(NoMethodError)
     end
   end
 


### PR DESCRIPTION
Refactored to display the 'fair dealing' link in the copyright info as plain text, as per changes to business requirements.