### PR TITLE
fix: update copyright messages from prod [BLAC-112]

### DIFF
--- a/app/components/copyright_info/_message1_1.html.erb
+++ b/app/components/copyright_info/_message1_1.html.erb
@@ -1,3 +1,3 @@
 <p>You may copy under some circumstances, for example you may copy a portion for research or study.
-  Order a copy through <%= copies_direct_link %> to the extent allowed under
-  fair dealing. <%= rights_contact_us_link %> for further information about copying.</p>
+  Order a copy through  <%= copies_direct_link %> to the extent allowed under fair dealing.
+  <%= rights_contact_us_link %> for further information about copying.</p>

--- a/app/components/copyright_info/_message1_2.html.erb
+++ b/app/components/copyright_info/_message1_2.html.erb
@@ -1,2 +1,2 @@
-<p>You may copy or order a copy through <%= copies_direct_link %>.
-  <%= rights_contact_us_link %> for further information about copying.</p>
+<p>You may copy or order a copy through <%= copies_direct_link %> or use the online copy for research or study;
+  for other uses <%= rights_contact_us_link %> for further information about copying.</p>

--- a/app/components/copyright_info/_message1_3.html.erb
+++ b/app/components/copyright_info/_message1_3.html.erb
@@ -1,3 +1,3 @@
 <p>You may have full rights to copy, or may be able to copy only under some circumstances, for example a portion for
-  research or study. Order a copy through <%= copies_direct_link %>&nbsp;to the extent allowed under
+  research or study. Order a copy through <%= copies_direct_link %> to the extent allowed under
   fair dealing. <%= rights_contact_us_link %> for further information about copying.</p>

--- a/app/components/copyright_info/_message2_1.html.erb
+++ b/app/components/copyright_info/_message2_1.html.erb
@@ -1,2 +1,2 @@
-<p>You may copy or order a copy through <%= copies_direct_link %>.
-  <%= rights_contact_us_link %> for further information about copying.</p>
+<p>You may copy or order a copy through <%= copies_direct_link %> or use the online copy for research or study;
+  for other uses <%= rights_contact_us_link %> for further information about copying.</p>

--- a/app/components/copyright_info/_message2_2.html.erb
+++ b/app/components/copyright_info/_message2_2.html.erb
@@ -1,3 +1,3 @@
-<p>Copyright varies with publication date of each issue. You may have full rights to copy, or may be able to copy only
-  under some circumstances, for example a portion for research or study. Order a copy through <%= copies_direct_link %>&nbsp;to
-  the extent allowed under fair dealing. <%= rights_contact_us_link %> for further information about copying.</p>
+<p>Copyright varies with each issue and article. You may have full rights to copy, or may be able to copy only under
+  some circumstances, for example a portion for research or study. Order a copy where circumstances allow through
+  <%= copies_direct_link %> or <%= rights_contact_us_link %> for further information.</p>

--- a/app/components/copyright_info/_message3.html.erb
+++ b/app/components/copyright_info/_message3.html.erb
@@ -1,1 +1,1 @@
-<p>If you wish to copy or order copies, <%= rights_contact_us_link %>.</p>
+<p>If you wish to copy or order copies, <%= rights_contact_us_link(lower: true) %>.</p>

--- a/app/components/copyright_info/_message4.html.erb
+++ b/app/components/copyright_info/_message4.html.erb
@@ -1,2 +1,1 @@
-<p>If you wish to copy or order copies, <%= rights_contact_us_link %>.
-  For access conditions return to the record display above.</p>
+<p>If you wish to copy or order copies, <%= rights_contact_us_link(lower: true) %>. For access conditions return to the record display above.</p>

--- a/app/components/copyright_info/_message5.html.erb
+++ b/app/components/copyright_info/_message5.html.erb
@@ -1,2 +1,3 @@
-<p>You may order a copy through <%= copies_direct_link %>&nbsp;or use the online copy for research or study; for other uses
-  <%= rights_contact_us_link %>.</p>
+<p>You may copy under some circumstances, for example you may copy a portion for research or study. Order a copy
+  through <%= copies_direct_link %> to the extent allowed under fair dealing.
+  <%= rights_contact_us_link %> for further information about copying.</p>

--- a/app/components/copyright_info/_message7.html.erb
+++ b/app/components/copyright_info/_message7.html.erb
@@ -1,2 +1,1 @@
-<p><%= rights_contact_us_link %> for information about copying.
-  For access conditions return to the record display above.</p>
+<p><%= rights_contact_us_link %> for information about copying. For access conditions return to the record display above.</p>

--- a/app/components/copyright_info/_message8.html.erb
+++ b/app/components/copyright_info/_message8.html.erb
@@ -1,2 +1,3 @@
-<p>You may order a copy through <%= copies_direct_link %>&nbsp;for research or study; for other uses
-  <%= rights_contact_us_link %>.</p>
+<p>You may copy under some circumstances, for example you may copy a portion for research or study.
+  Order a copy through <%= copies_direct_link %> to the extent allowed under fair dealing.
+  <%= rights_contact_us_link %> for further information about copying.</p>

--- a/app/helpers/copyright_helper.rb
+++ b/app/helpers/copyright_helper.rb
@@ -1,6 +1,7 @@
 module CopyrightHelper
-  def rights_contact_us_link
-    link_to "Contact us", ENV["COPYRIGHT_CONTACT_URL"]
+  def rights_contact_us_link(lower: false)
+    link_text = lower ? "contact us" : "Contact us"
+    link_to link_text, ENV["COPYRIGHT_CONTACT_URL"]
   end
 
   def copies_direct_link

--- a/spec/components/copyright_info_component_spec.rb
+++ b/spec/components/copyright_info_component_spec.rb
@@ -170,13 +170,6 @@ RSpec.describe CopyrightInfoComponent, type: :component do
       expect(page.text).to include "Copies Direct"
       expect(page).to have_xpath("//a[@href='javascript:;']")
     end
-
-    it "renders the 'fair dealing' as text" do
-      render_inline(described_class.new(copyright: copyright))
-
-      expect(page.text).to include "fair dealing"
-      expect(page).not_to have_xpath("//a[text()='fair dealing']")
-    end
   end
 
   context "when status context message is 3" do
@@ -198,6 +191,13 @@ RSpec.describe CopyrightInfoComponent, type: :component do
       expect(page.text).not_to include "Copies Direct"
       expect(page).not_to have_xpath("//a[@href='javascript:;']")
     end
+
+    it "renders a lowercase contact us link" do
+      render_inline(described_class.new(copyright: copyright))
+
+      expect(page.text).to include "contact us"
+      expect(page).to have_xpath("//a[@href='https://example.com/contact-us']")
+    end
   end
 
   context "when status context message is 4" do
@@ -218,6 +218,13 @@ RSpec.describe CopyrightInfoComponent, type: :component do
 
       expect(page.text).not_to include "Copies Direct"
       expect(page).not_to have_xpath("//a[@href='javascript:;']")
+    end
+
+    it "renders a lowercase contact us link" do
+      render_inline(described_class.new(copyright: copyright))
+
+      expect(page.text).to include "contact us"
+      expect(page).to have_xpath("//a[@href='https://example.com/contact-us']")
     end
   end
 


### PR DESCRIPTION
It would help to double check which version of the VuFind source code I was copying stuff from next time. 🤦‍♀️ 

These should match what's in the prod templates now.