### PR TITLE
refactor: only use '022z' for invalid ISSN

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -147,9 +147,7 @@ class SolrDocument
   end
 
   def invalid_issn
-    invalid_issn = get_marc_derived_field("022y", options: {alternate_script: false})
-    invalid_issn = get_marc_derived_field("022z", options: {alternate_script: false}) if invalid_issn.empty?
-    invalid_issn
+    get_marc_derived_field("022z", options: {alternate_script: false})
   end
 
   def ismn


### PR DESCRIPTION
Acceptance criteria was updated to only retrieve values from '022z'