### PR TITLE
fix: make bib id search query only the bib id field

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -270,7 +270,9 @@ class CatalogController < ApplicationController
 
     config.add_search_field("id") do |field|
       field.label = "Bib Id"
-      field.qt = "search"
+      field.solr_parameters = {
+        qf: "id"
+      }
     end
 
     config.add_search_field("occupation") do |field|


### PR DESCRIPTION
bib id search returns partial matches since it's set up using the default search. Changed to limit query to id field.