### PR TITLE
fix: checks if url should render broken links caption [BLAC-153]

### DIFF
--- a/app/helpers/field_helper.rb
+++ b/app/helpers/field_helper.rb
@@ -24,7 +24,7 @@ module FieldHelper
           content_tag(:li) do
             list_content = []
             list_content << link_to(link[:text], link[:href])
-            if document.has_broken_links?
+            if document.has_broken_links? && document.broken_links[link[:href]]
               list_content << content_tag(:p, class: "small") do
                 build_broken_link(document.broken_links[link[:href]])
               end
@@ -37,7 +37,7 @@ module FieldHelper
       link = value.first
       elements << link_to(link[:text], link[:href])
 
-      if document.has_broken_links?
+      if document.has_broken_links? && document.broken_links[link[:href]]
         elements << content_tag(:p, class: "small") do
           build_broken_link(document.broken_links[link[:href]])
         end

--- a/spec/helpers/field_helper_spec.rb
+++ b/spec/helpers/field_helper_spec.rb
@@ -68,6 +68,21 @@ RSpec.describe FieldHelper do
         expect(document).not_to have_broken_links
       end
     end
+
+    context "when there aren't broken links for url" do
+      let(:value) {
+        [{
+          text: "Online version. Click on provided links to display issues available; then click on index of city codes to view particular issues.",
+          href: "https://purl.access.gpo.gov/GPO/LPS1384"
+        }]
+      }
+
+      let(:document) { SolrDocument.new(marc_ss: some_broken_links_marc) }
+
+      it "does not generate broken links text" do
+        expect(document.broken_links[value.first[:href]]).to be_nil
+      end
+    end
   end
 
   describe "#list" do
@@ -454,6 +469,10 @@ RSpec.describe FieldHelper do
 
   def no_broken_links_marc
     load_marc_from_file 113030
+  end
+
+  def some_broken_links_marc
+    load_marc_from_file 3823089
   end
 
   def full_contents_marc


### PR DESCRIPTION
So, originally the `#url_list` helper method was only used to display the Online Access, Online Version fields, but I recently added the Rights Information field and set it to use the `#url_list` helper. This was a mistake because this URL will never have "broken links" generated for it. 

As such, I've added a check to make sure that if there are "broken links", that they are for the actual URL being displayed for the field.