### PR TITLE
fix: fix permissions on vendor/bundle dir at deployment

### DIFF
--- a/nla-deploy.sh
+++ b/nla-deploy.sh
@@ -39,6 +39,9 @@ bundle install
 RAILS_ENV=$RAILS_ENV bundle exec rails db:migrate
 RAILS_ENV=$RAILS_ENV bundle exec rails assets:precompile
 
+# try to fix permissions in vendor/bundle
+chmod -R o+r ./vendor/bundle
+
 mkdir -p "$BLACKLIGHT_TMP_PATH"/pids
 
 # Using file cache, so tmp:clear will also clear the cache


### PR DESCRIPTION
The issue was related to some files of the mail gem having "640" permissions instead of "644".

```
-rw-r-----.  1 root root 2.2K Dec  9 10:06 fields.rb
-rw-r-----.  1 root root 3.8K Dec  9 10:06 indifferent_hash.rb
```

Even though the permissions on delong are the same, somehow, the application can't load them on deshort.

This workaround just changes the permissions on the "vendor/bundle" directory and it's contents to allow puma to load the gems.