### PR TITLE
BLAC-168 - search results metadata layout to use bootstrap markup

### DIFF
--- a/app/assets/stylesheets/nla/_search-results.scss
+++ b/app/assets/stylesheets/nla/_search-results.scss
@@ -11,5 +11,11 @@
       background: color("white");
       box-shadow: 3px 3px 6px 0 rgba(112,57,150,0.1);
     }
+    
+    .document-thumbnail {
+      float: none;
+      margin-bottom: 0;
+      padding-left: 0;
+    }
   }
 }

--- a/app/components/blacklight/document/thumbnail_component.html.erb
+++ b/app/components/blacklight/document/thumbnail_component.html.erb
@@ -1,0 +1,12 @@
+<% value = use_thumbnail_tag_behavior? ? presenter.thumbnail.thumbnail_tag(@image_options, 'aria-hidden': true, tabindex: -1, counter: @counter) : presenter.thumbnail.render(@image_options) %>
+
+<% if value %>
+  <div class="document-thumbnail col-4 col-md-2 order-3">
+    <% if use_thumbnail_tag_behavior? %>
+      <% warn_about_deprecated_behavior %>
+      <%= value %>
+    <% else %>
+      <%= helpers.link_to_document(presenter.document, value, 'aria-hidden': true, tabindex: -1, counter: @counter) %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/components/blacklight/document_component.html.erb
+++ b/app/components/blacklight/document_component.html.erb
@@ -1,0 +1,27 @@
+<%= content_tag @component,
+  id: @id,
+  data: {
+    'document-id': @document.id.to_s.parameterize,
+    'document-counter': @counter,
+  },
+  itemscope: true,
+  itemtype: @document.itemtype,
+  class: classes.flatten.join(' ') do %>
+  <%= header %>
+  <% if body.present? %>
+    <%= body %>
+  <% else %>
+    <div class="document-main-section">
+      <%= title %>
+      <%= embed %>
+      <%= content %>
+      <%= metadata %>
+      <% metadata_sections.each do |section| %>
+        <%= section %>
+      <% end %>
+    </div>
+
+    <%= thumbnail %>
+  <% end %>
+  <%= footer %>
+<% end %>

--- a/app/components/blacklight/document_component.rb
+++ b/app/components/blacklight/document_component.rb
@@ -25,7 +25,7 @@ module Blacklight
       next static_content if static_content.present?
       next unless component
 
-      Deprecation.warn(Blacklight::DocumentComponent, 'Pass the presenter to the DocumentComponent') if @presenter.nil?
+      Deprecation.warn(Blacklight::DocumentComponent, "Pass the presenter to the DocumentComponent") if @presenter.nil?
 
       component.new(*args, document: @document, presenter: @presenter, document_counter: @document_counter, **kwargs)
     end)
@@ -34,7 +34,7 @@ module Blacklight
     renders_one :metadata, (lambda do |static_content = nil, *args, component: nil, fields: nil, **kwargs|
       next static_content if static_content.present?
 
-      Deprecation.warn(Blacklight::DocumentComponent, 'Pass the presenter to the DocumentComponent') if !fields && @presenter.nil?
+      Deprecation.warn(Blacklight::DocumentComponent, "Pass the presenter to the DocumentComponent") if !fields && @presenter.nil?
 
       component ||= Blacklight::DocumentMetadataComponent
 
@@ -48,7 +48,7 @@ module Blacklight
       next image_options_or_static_content if image_options_or_static_content.is_a? String
 
       component ||= @presenter&.view_config&.thumbnail_component || Blacklight::Document::ThumbnailComponent
-      Deprecation.warn(Blacklight::DocumentComponent, 'Pass the presenter to the DocumentComponent') if !component && @presenter.nil?
+      Deprecation.warn(Blacklight::DocumentComponent, "Pass the presenter to the DocumentComponent") if !component && @presenter.nil?
 
       component.new(*args, document: @document, presenter: @presenter, counter: @counter, image_options: image_options_or_static_content, **kwargs)
     end)
@@ -74,14 +74,14 @@ module Blacklight
     # @param counter_offset [Number] with `document_counter`, the offset of the start of that collection counter to the overall result set
     # @param show [Boolean] are we showing only a single document (vs a list of search results); used for backwards-compatibility
     def initialize(document: nil, presenter: nil,
-                   id: nil, classes: [], component: :article, title_component: nil,
-                   metadata_component: nil,
-                   embed_component: nil,
-                   thumbnail_component: nil,
-                   counter: nil, document_counter: nil, counter_offset: 0,
-                   show: false)
+      id: nil, classes: [], component: :article, title_component: nil,
+      metadata_component: nil,
+      embed_component: nil,
+      thumbnail_component: nil,
+      counter: nil, document_counter: nil, counter_offset: 0,
+      show: false)
       if presenter.nil? && document.nil?
-        raise ArgumentError, 'missing keyword: :document or :presenter'
+        raise ArgumentError, "missing keyword: :document or :presenter"
       end
 
       @document = document || presenter&.document
@@ -89,16 +89,16 @@ module Blacklight
 
       @component = component
       @title_component = title_component
-      @id = id || ('document' if show)
+      @id = id || ("document" if show)
       @classes = classes
 
-      Deprecation.warn(Blacklight::DocumentComponent, 'Passing embed_component is deprecated') if @embed_component.present?
+      Deprecation.warn(Blacklight::DocumentComponent, "Passing embed_component is deprecated") if @embed_component.present?
       @embed_component = embed_component
 
-      Deprecation.warn(Blacklight::DocumentComponent, 'Passing metadata_component is deprecated') if @metadata_component.present?
+      Deprecation.warn(Blacklight::DocumentComponent, "Passing metadata_component is deprecated") if @metadata_component.present?
       @metadata_component = metadata_component || Blacklight::DocumentMetadataComponent
 
-      Deprecation.warn(Blacklight::DocumentComponent, 'Passing thumbnail_component is deprecated') if @thumbnail_component.present?
+      Deprecation.warn(Blacklight::DocumentComponent, "Passing thumbnail_component is deprecated") if @thumbnail_component.present?
       @thumbnail_component = thumbnail_component || Blacklight::Document::ThumbnailComponent
 
       @document_counter = document_counter
@@ -114,7 +114,7 @@ module Blacklight
       [
         @classes,
         helpers.render_document_class(@document),
-        'document row',
+        "document row",
         ("document-position-#{@counter}" if @counter)
       ].compact.flatten
     end

--- a/app/components/blacklight/document_component.rb
+++ b/app/components/blacklight/document_component.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+module Blacklight
+  class DocumentComponent < Blacklight::Component
+    include Blacklight::ContentAreasShim
+
+    # Content appearing before the document
+    renders_one :header
+
+    # Content appearing after the document
+    renders_one :footer
+
+    # Content appearing instead of the regularly rendered document; its use is discouraged, but is a stop-gap until
+    # the ecosystem fully adopts view components.
+    renders_one :body
+
+    # The document title with some reasonable default behavior
+    renders_one :title, (lambda do |*args, component: nil, **kwargs|
+      component ||= Blacklight::DocumentTitleComponent
+
+      component.new(*args, counter: @counter, document: @document, presenter: @presenter, as: @title_component, link_to_document: !@show, document_component: self, **kwargs)
+    end)
+
+    renders_one :embed, (lambda do |static_content = nil, *args, component: nil, **kwargs|
+      next static_content if static_content.present?
+      next unless component
+
+      Deprecation.warn(Blacklight::DocumentComponent, 'Pass the presenter to the DocumentComponent') if @presenter.nil?
+
+      component.new(*args, document: @document, presenter: @presenter, document_counter: @document_counter, **kwargs)
+    end)
+
+    # The primary metadata section
+    renders_one :metadata, (lambda do |static_content = nil, *args, component: nil, fields: nil, **kwargs|
+      next static_content if static_content.present?
+
+      Deprecation.warn(Blacklight::DocumentComponent, 'Pass the presenter to the DocumentComponent') if !fields && @presenter.nil?
+
+      component ||= Blacklight::DocumentMetadataComponent
+
+      component.new(*args, fields: fields || @presenter&.field_presenters || [], **kwargs)
+    end)
+
+    # Additional metadata sections
+    renders_many :metadata_sections
+
+    renders_one :thumbnail, (lambda do |image_options_or_static_content = {}, *args, component: nil, **kwargs|
+      next image_options_or_static_content if image_options_or_static_content.is_a? String
+
+      component ||= @presenter&.view_config&.thumbnail_component || Blacklight::Document::ThumbnailComponent
+      Deprecation.warn(Blacklight::DocumentComponent, 'Pass the presenter to the DocumentComponent') if !component && @presenter.nil?
+
+      component.new(*args, document: @document, presenter: @presenter, counter: @counter, image_options: image_options_or_static_content, **kwargs)
+    end)
+
+    # A container for partials rendered using the view config partials configuration. Its use is discouraged, but necessary until
+    # the ecosystem fully adopts view components.
+    renders_many :partials
+
+    # Backwards compatibility
+    renders_one :actions
+
+    with_collection_parameter :document
+
+    # rubocop:disable Metrics/ParameterLists
+    # @param document [Blacklight::Document]
+    # @param presenter [Blacklight::DocumentPresenter]
+    # @param id [String] HTML id for the root element
+    # @param classes [Array, String] additional HTML classes for the root element
+    # @param component [Symbol, String] HTML tag type to use for the root element
+    # @param title_component [Symbol, String] HTML tag type to use for the title element
+    # @param counter [Number, nil] a pre-computed counter for the position of this document in a search result set
+    # @param document_counter [Number, nil] alternatively, the document's position in a collection and,
+    # @param counter_offset [Number] with `document_counter`, the offset of the start of that collection counter to the overall result set
+    # @param show [Boolean] are we showing only a single document (vs a list of search results); used for backwards-compatibility
+    def initialize(document: nil, presenter: nil,
+                   id: nil, classes: [], component: :article, title_component: nil,
+                   metadata_component: nil,
+                   embed_component: nil,
+                   thumbnail_component: nil,
+                   counter: nil, document_counter: nil, counter_offset: 0,
+                   show: false)
+      if presenter.nil? && document.nil?
+        raise ArgumentError, 'missing keyword: :document or :presenter'
+      end
+
+      @document = document || presenter&.document
+      @presenter = presenter
+
+      @component = component
+      @title_component = title_component
+      @id = id || ('document' if show)
+      @classes = classes
+
+      Deprecation.warn(Blacklight::DocumentComponent, 'Passing embed_component is deprecated') if @embed_component.present?
+      @embed_component = embed_component
+
+      Deprecation.warn(Blacklight::DocumentComponent, 'Passing metadata_component is deprecated') if @metadata_component.present?
+      @metadata_component = metadata_component || Blacklight::DocumentMetadataComponent
+
+      Deprecation.warn(Blacklight::DocumentComponent, 'Passing thumbnail_component is deprecated') if @thumbnail_component.present?
+      @thumbnail_component = thumbnail_component || Blacklight::Document::ThumbnailComponent
+
+      @document_counter = document_counter
+      @counter = counter
+      @counter ||= document_counter + 1 + counter_offset if document_counter.present?
+
+      @show = show
+    end
+    # rubocop:enable Metrics/ParameterLists
+
+    # HTML classes to apply to the root element
+    def classes
+      [
+        @classes,
+        helpers.render_document_class(@document),
+        'document row',
+        ("document-position-#{@counter}" if @counter)
+      ].compact.flatten
+    end
+
+    def before_render
+      set_slot(:title, nil) unless title
+      set_slot(:thumbnail, nil, component: @thumbnail_component || presenter.view_config&.thumbnail_component) unless thumbnail || show?
+      set_slot(:metadata, nil, component: @metadata_component, fields: presenter.field_presenters) unless metadata
+      set_slot(:embed, nil, component: @embed_component || presenter.view_config&.embed_component) unless embed
+    end
+
+    private
+
+    def presenter
+      @presenter ||= helpers.document_presenter(@document)
+    end
+
+    def show?
+      @show
+    end
+  end
+end

--- a/app/components/blacklight/document_metadata_component.html.erb
+++ b/app/components/blacklight/document_metadata_component.html.erb
@@ -1,0 +1,7 @@
+<div class="col order-2">
+  <dl class="document-metadata dl-invert row">
+    <% fields.each do |field| -%>
+      <%= field %>
+    <% end -%>
+  </dl>
+</div>

--- a/app/components/blacklight/metadata_field_component.html.erb
+++ b/app/components/blacklight/metadata_field_component.html.erb
@@ -1,0 +1,8 @@
+<%= render(@layout.new(field: @field)) do |component| %>
+  <% component.label do %>
+    <%= label %>
+  <% end %>
+  <% component.value do %>
+    <%= @field.render %>
+  <% end %>
+<% end %>

--- a/app/components/blacklight/metadata_field_component.rb
+++ b/app/components/blacklight/metadata_field_component.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Blacklight
+  class MetadataFieldComponent < Blacklight::Component
+    with_collection_parameter :field
+
+    # @param field [Blacklight::FieldPresenter]
+    # @param layout [Blacklight::MetadataFieldLayoutComponent] alternate layout component to use
+    # @param show [Boolean] are we showing only a single document (vs a list of search results); used for backwards-compatibility
+    def initialize(field:, layout: nil, show: false)
+      @field = field
+      @layout = layout || Blacklight::MetadataFieldLayoutComponent
+      @show = show
+    end
+
+    # @private
+    def label
+      Deprecation.silence(Blacklight::BlacklightHelperBehavior) do
+        if @show
+          helpers.render_document_show_field_label @field.document, label: @field.label('show'), field: @field.key
+        else
+          helpers.render_index_field_label @field.document, label: @field.label, field: @field.key
+        end
+      end
+    end
+
+    def render?
+      @field.render_field?
+    end
+  end
+end

--- a/app/components/blacklight/metadata_field_component.rb
+++ b/app/components/blacklight/metadata_field_component.rb
@@ -17,7 +17,7 @@ module Blacklight
     def label
       Deprecation.silence(Blacklight::BlacklightHelperBehavior) do
         if @show
-          helpers.render_document_show_field_label @field.document, label: @field.label('show'), field: @field.key
+          helpers.render_document_show_field_label @field.document, label: @field.label("show"), field: @field.key
         else
           helpers.render_index_field_label @field.document, label: @field.label, field: @field.key
         end

--- a/app/components/blacklight/metadata_field_layout_component.html.erb
+++ b/app/components/blacklight/metadata_field_layout_component.html.erb
@@ -1,0 +1,4 @@
+<dt class="blacklight-<%= @key %> <%= @label_class %>"><%= label %></dt>
+<% values.each do |v| %>
+  <%= v %>
+<% end %>

--- a/app/components/blacklight/metadata_field_layout_component.rb
+++ b/app/components/blacklight/metadata_field_layout_component.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Blacklight
+  class MetadataFieldLayoutComponent < Blacklight::Component
+    include Blacklight::ContentAreasShim
+
+    with_collection_parameter :field
+    renders_one :label
+    renders_many :values, (lambda do |value: nil, &block|
+      if block
+        content_tag :dd, class: "#{@value_class} blacklight-#{@key}", &block
+      else
+        content_tag :dd, value, class: "#{@value_class} blacklight-#{@key}"
+      end
+    end)
+
+    # @param field [Blacklight::FieldPresenter]
+    def initialize(field:, label_class: 'col-12 col-md-3', value_class: 'col col-sm-9')
+      @field = field
+      @key = @field.key.parameterize
+      @label_class = label_class
+      @value_class = value_class
+    end
+
+    def value(*args, **kwargs, &block)
+      return set_slot(:values, nil, *args, **kwargs, &block) if block_given?
+
+      Deprecation.warn(Blacklight::MetadataFieldLayoutComponent, 'The `value` content area is deprecated; render from the values slot instead')
+
+      values.first
+    end
+
+    def with(slot_name, *args, **kwargs, &block)
+      if slot_name == :value
+        super(:values, *args, **kwargs, &block)
+      else
+        super
+      end
+    end
+  end
+end

--- a/app/components/blacklight/metadata_field_layout_component.rb
+++ b/app/components/blacklight/metadata_field_layout_component.rb
@@ -15,7 +15,7 @@ module Blacklight
     end)
 
     # @param field [Blacklight::FieldPresenter]
-    def initialize(field:, label_class: 'col-12 col-md-3', value_class: 'col col-sm-9')
+    def initialize(field:, label_class: "col-12 col-md-3", value_class: "col col-sm-9")
       @field = field
       @key = @field.key.parameterize
       @label_class = label_class
@@ -23,9 +23,9 @@ module Blacklight
     end
 
     def value(*args, **kwargs, &block)
-      return set_slot(:values, nil, *args, **kwargs, &block) if block_given?
+      return set_slot(:values, nil, *args, **kwargs, &block) if block
 
-      Deprecation.warn(Blacklight::MetadataFieldLayoutComponent, 'The `value` content area is deprecated; render from the values slot instead')
+      Deprecation.warn(Blacklight::MetadataFieldLayoutComponent, "The `value` content area is deprecated; render from the values slot instead")
 
       values.first
     end

--- a/app/presenters/nla_thumbnail_presenter.rb
+++ b/app/presenters/nla_thumbnail_presenter.rb
@@ -25,7 +25,7 @@ class NlaThumbnailPresenter < Blacklight::ThumbnailPresenter
 
   # @param [Hash] image_options to pass to the image tag
   def thumbnail_value(image_options)
-    image_options = image_options.merge({alt: alt_title_from_document, onerror: "this.style.display='none'"})
+    image_options = image_options.merge({alt: alt_title_from_document, onerror: "this.style.display='none'", class: "w-100"})
     value = if thumbnail_method
       view_context.send(thumbnail_method, document, image_options)
     elsif thumbnail_field

--- a/app/views/catalog/_index_header.html.erb
+++ b/app/views/catalog/_index_header.html.erb
@@ -1,0 +1,22 @@
+<%# header bar for doc items in index view -%>
+<header class="documentHeader order-1 col-12">
+  <%# main title container for doc partial view
+      How many bootstrap columns need to be reserved
+      for bookmarks control depends on size.
+  -%>
+  <% document_actions = capture do %>
+    <% # bookmark functions for items/docs -%>
+    <%= render_index_doc_actions document, wrapping_class: "index-document-functions col-sm-3 col-lg-2" %>
+  <% end %>
+
+  <h3 class="index_title document-title-heading <%= document_actions.present? ? "col-sm-9 col-lg-10" : "" %>">
+    <% if counter = document_counter_with_offset(document_counter) %>
+      <span class="document-counter">
+        <%= t('blacklight.search.documents.counter', counter: counter) %>
+      </span>
+    <% end %>
+    <%= link_to_document document, counter: counter %>
+  </h3>
+
+  <%= document_actions %>
+</header>

--- a/spec/presenters/nla_thumbnail_presenter_spec.rb
+++ b/spec/presenters/nla_thumbnail_presenter_spec.rb
@@ -99,11 +99,11 @@ RSpec.describe NlaThumbnailPresenter do
       let(:presenter) { described_class.new(document, view_context, config) }
 
       it "generates a small linked thumbnail" do
-        allow(view_context).to receive(:image_tag).with("image.png/image?wid=123", {alt: "Work Title", onerror: "this.style.display='none'"})
-          .and_return('<img src="image.png/image?wid=123" alt="Work Title" onerror="this.style.display=\'none\'" />')
+        allow(view_context).to receive(:image_tag).with("image.png/image?wid=123", {alt: "Work Title", onerror: "this.style.display='none'", class: "w-100"})
+          .and_return('<img src="image.png/image?wid=123" alt="Work Title" onerror="this.style.display=\'none\'" class="w-100" />')
 
-        allow(view_context).to receive(:link_to_document).with(document, '<img src="image.png/image?wid=123" alt="Work Title" onerror="this.style.display=\'none\'" />', {})
-          .and_return('<a href="http://example.com/catalog/1"><img src="image.png/image?wid=123" alt="Work Title" onerror="this.style.display=\'none\'" /></a>')
+        allow(view_context).to receive(:link_to_document).with(document, '<img src="image.png/image?wid=123" alt="Work Title" onerror="this.style.display=\'none\'" class="w-100" />', {})
+          .and_return('<a href="http://example.com/catalog/1"><img src="image.png/image?wid=123" alt="Work Title" onerror="this.style.display=\'none\'" class="w-100" /></a>')
 
         expect(tag).to include 'href="http://example.com/catalog/1"'
 
@@ -120,11 +120,11 @@ RSpec.describe NlaThumbnailPresenter do
       let(:presenter) { described_class.new(document, view_context, config) }
 
       it "generates a small linked thumbnail" do
-        allow(view_context).to receive(:image_tag).with("image.png/image?wid=500", {alt: "Work Title", onerror: "this.style.display='none'"})
-          .and_return('<img src="image.png/image?wid=500" alt="Work Title" onerror="this.style.display=\'none\'" />')
+        allow(view_context).to receive(:image_tag).with("image.png/image?wid=500", {alt: "Work Title", onerror: "this.style.display='none'", class: "w-100"})
+          .and_return('<img src="image.png/image?wid=500" alt="Work Title" onerror="this.style.display=\'none\'" class="w-100" />')
 
-        allow(view_context).to receive(:link_to_document).with(document, '<img src="image.png/image?wid=500" alt="Work Title" onerror="this.style.display=\'none\'" />', {})
-          .and_return('<a href="https://nla.gov.au/nla.obj1234567"><img src="image.png/image?wid=500" alt="Work Title" onerror="this.style.display=\'none\'" /></a>')
+        allow(view_context).to receive(:link_to_document).with(document, '<img src="image.png/image?wid=500" alt="Work Title" onerror="this.style.display=\'none\'" class="w-100" />', {})
+          .and_return('<a href="https://nla.gov.au/nla.obj1234567"><img src="image.png/image?wid=500" alt="Work Title" onerror="this.style.display=\'none\'" class="w-100" /></a>')
 
         expect(tag).to include 'href="https://nla.gov.au/nla.obj1234567"'
 


### PR DESCRIPTION
Update the markup to use core bootstrap markup/layout properties rather than CSS floats. This does impact the display of the image on detail record pages