### PR TITLE
fix: modify Author display [BLAC-15]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -618,4 +618,4 @@ RUBY VERSION
    ruby 3.2.0p0
 
 BUNDLED WITH
-   2.4.4
+   2.4.5

--- a/app/components/related_records_component.html.erb
+++ b/app/components/related_records_component.html.erb
@@ -1,5 +1,10 @@
 <% if collection_name.present? %>
-  <p>This record belongs to the <%= link_to "#{collection_name} collection.", collection_url %></p>
+  <p>This record belongs to the
+    <% if collection_url.present? %>
+      <%= link_to "#{collection_name} collection.", collection_url %>
+    <% else %>
+      <%= "#{collection_name} collection." %>
+    <% end %></p>
 <% end %>
 <p class="mb-0">This collection is made up of <%= "#{formatted_collection_count} #{'record'.pluralize(collection_count)}" %>:</p>
 <ul class="list-unstyled">

--- a/app/components/related_records_component.rb
+++ b/app/components/related_records_component.rb
@@ -21,10 +21,14 @@ class RelatedRecordsComponent < ViewComponent::Base
   end
 
   def collection_url
-    solr_document_path(id: parent_record.first[:id])
+    if parent_record.present?
+      solr_document_path(id: parent_record.first[:id])
+    end
   end
 
   def collection_records_url
-    search_catalog_path(search_field: "in_collection", q: "\"#{collection_id}\"")
+    if collection_id.present?
+      search_catalog_path(search_field: "in_collection", q: "\"#{collection_id}\"")
+    end
   end
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -154,7 +154,7 @@ class CatalogController < ApplicationController
     config.add_show_field "id", label: "Bib ID", field: "id"
     config.add_show_field field: "format", label: "Format"
     config.add_show_field "form_of_work", label: "Form of work", accessor: :form_of_work, helper_method: :list
-    config.add_show_field "author", field: "author_tsim", label: "Author"
+    config.add_show_field "author", field: "author_with_relator_ssim", label: "Author", helper_method: :author_link
     config.add_show_field "translated_title", label: "Translated Title", accessor: :translated_title
     config.add_show_field "uniform_title", label: "Uniform Title", accessor: :uniform_title
     config.add_show_field "online_access", label: "Online Access", accessor: :online_access, helper_method: :url_list

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -135,7 +135,7 @@ class CatalogController < ApplicationController
     #   The ordering of the field names is the order of the display
     config.add_index_field "title_tsim", label: "Title"
     config.add_index_field "title_vern_ssim", label: "Title"
-    config.add_index_field "author_tsim", label: "Author"
+    config.add_index_field "author_with_relator_ssim", label: "Author"
     config.add_index_field "author_vern_ssim", label: "Author"
     config.add_index_field "format", label: "Format"
     config.add_index_field "language_ssim", label: "Language"

--- a/app/helpers/field_helper.rb
+++ b/app/helpers/field_helper.rb
@@ -160,6 +160,10 @@ module FieldHelper
     catalogue_search_list(value, "title", bulleted: true)
   end
 
+  def author_link(document:, field:, config:, value:, context:)
+    catalogue_search_list(value, "author", bulleted: false)
+  end
+
   private
 
   # Original RegEx used by VuFind

--- a/app/presenters/nla_thumbnail_presenter.rb
+++ b/app/presenters/nla_thumbnail_presenter.rb
@@ -43,8 +43,8 @@ class NlaThumbnailPresenter < Blacklight::ThumbnailPresenter
         else
           "/image?wid=123"
         end
+        view_context.image_tag image_url, image_options if image_url.present?
       end
-      view_context.image_tag image_url, image_options if image_url.present?
     end
 
     value || default_thumbnail_value(image_options)

--- a/spec/files/related_records/no_parent_record_response.json
+++ b/spec/files/related_records/no_parent_record_response.json
@@ -1,0 +1,21 @@
+{
+  "responseHeader": {
+    "zkConnected": true,
+    "status": 0,
+    "QTime": 124,
+    "params": {
+      "q": "collection_id_ssi:\"unknown\"",
+      "fl": "id,title_tsim",
+      "sort": "score desc, pub_date_si desc, title_si asc",
+      "rows": "0",
+      "wt": "json"
+    }
+  },
+  "response": {
+    "numFound": 0,
+    "start": 0,
+    "maxScore": 11.214123,
+    "numFoundExact": true,
+    "docs": []
+  }
+}


### PR DESCRIPTION
Modifies the display value of the Author field on the search results and catalogue record pages to use `author_with_relator_ssim`. Also linked the field values to an "author search".

In addition, modified the RelatedRecord component to not try to link to the collection parent record if somehow a parent record cannot be found. In theory this should not happen once changes in BLAC-195 are deployed.