### PR TITLE
fix: use "author_search_tsim" as the author search field [BLAC-15]

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -273,8 +273,8 @@ class CatalogController < ApplicationController
     config.add_search_field("author") do |field|
       field.solr_parameters = {
         "spellcheck.dictionary": "author",
-        qf: "${author_qf}",
-        pf: "${author_pf}"
+        qf: "author_search_tsim",
+        pf: "author_search_tsim"
       }
     end
 


### PR DESCRIPTION
This change will allow the search to return books even when the author in the search term is not the primary author.