### PR TITLE
fix: restore hidden field removed from advanced search page [BLAC-208]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,7 @@ GEM
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
-    bindata (2.4.14)
+    bindata (2.4.15)
     bindex (0.8.1)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)

--- a/app/views/advanced/_advanced_search_submit_btns.html.erb
+++ b/app/views/advanced/_advanced_search_submit_btns.html.erb
@@ -1,5 +1,7 @@
-      <div class="submit-buttons pull-right">
-        <%= link_to t('blacklight_advanced_search.form.start_over'), blacklight_advanced_search_engine.advanced_search_path, :class =>"btn btn-secondary advanced-search-start-over" %>
+<%# DO NOT REMOVE THIS HIDDEN FIELD OR ADVANCED SEARCH WILL STOP WORKING!!! %>
+<%= hidden_field_tag(:search_field, blacklight_config.advanced_search[:url_key]) %>
+<div class="submit-buttons pull-right">
+  <%= link_to t('blacklight_advanced_search.form.start_over'), blacklight_advanced_search_engine.advanced_search_path, :class =>"btn btn-secondary advanced-search-start-over" %>
 
-        <%= submit_tag t('blacklight_advanced_search.form.search_btn'), :class=>'btn btn-primary advanced-search-submit', :id => "advanced-search-submit" %>
-      </div>
+  <%= submit_tag t('blacklight_advanced_search.form.search_btn'), :class=>'btn btn-primary advanced-search-submit', :id => "advanced-search-submit" %>
+</div>


### PR DESCRIPTION
Didn't realise that the `<div>` that included the sort drop down on the Advanced Search page included a hidden text field. Removing this caused the Advanced Search to ignore the search term and redirect to the home page instead of performing a search.

I've restored the hidden text field and upgraded dependencies.