### PR TITLE
BLAC-262 Improve relevance ranking

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -15,7 +15,7 @@ class CatalogController < ApplicationController
     config.advanced_search ||= Blacklight::OpenStructWithHashAccess.new
     # config.advanced_search[:qt] ||= 'advanced'
     config.advanced_search[:url_key] ||= "advanced"
-    config.advanced_search[:query_parser] ||= "dismax"
+    config.advanced_search[:query_parser] ||= "edismax"
     config.advanced_search[:form_solr_parameters] ||= {}
 
     ## Class for sending and receiving requests from a search index
@@ -34,7 +34,9 @@ class CatalogController < ApplicationController
 
     ## Default parameters to send to solr for all search-like requests. See also SearchBuilder#processed_parameters
     config.default_solr_params = {
-      rows: 10
+      rows: 10,
+      qf: "id title_tsim^10 title_addl_tsim author_search_tsim subject_tsimv call_number_tsim all_text_timv",
+      pf: "id title_tsim title_addl_tsim author_search_tsim subject_tsimv"
     }
 
     # solr path which will be added to solr base url before the other solr params.
@@ -258,12 +260,14 @@ class CatalogController < ApplicationController
     # case for a BL "search field", which is really a dismax aggregate
     # of Solr search fields.
 
+    config.solr_bf_title_boost = "mul(termfreq(title_tsim,$q),100)"
+
     config.add_search_field("title") do |field|
       # solr_parameters hash are sent to Solr as ordinary url query params.
       field.solr_parameters = {
         "spellcheck.dictionary": "title",
-        qf: "title_search_tsim",
-        pf: "title_search_tsim"
+        qf: "id title_tsim^10 title_addl_tsim",
+        pf: "id title_tsim title_addl_tsim"
       }
     end
 

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -16,7 +16,7 @@ class SearchBuilder < Blacklight::SearchBuilder
   #   end
 
   def add_title_boost_to_query(solr_parameters)
-    unless blacklight_params[:q].blank?
+    if blacklight_params[:q].present?
       solr_parameters[:bf] = blacklight_config.solr_bf_title_boost
     end
   end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -5,7 +5,7 @@ class SearchBuilder < Blacklight::SearchBuilder
   include BlacklightRangeLimit::RangeLimitBuilder
 
   include BlacklightAdvancedSearch::AdvancedSearchBuilder
-  self.default_processor_chain += [:add_advanced_parse_q_to_solr, :add_advanced_search_to_solr]
+  self.default_processor_chain += [:add_advanced_parse_q_to_solr, :add_advanced_search_to_solr, :add_title_boost_to_query]
 
   ##
   # @example Adding a new step to the processor chain
@@ -14,4 +14,10 @@ class SearchBuilder < Blacklight::SearchBuilder
   #   def add_custom_data_to_query(solr_parameters)
   #     solr_parameters[:custom] = blacklight_params[:user_value]
   #   end
+
+  def add_title_boost_to_query(solr_parameters)
+    unless blacklight_params[:q].blank?
+      solr_parameters[:bf] = blacklight_config.solr_bf_title_boost
+    end
+  end
 end


### PR DESCRIPTION
Use edismax parser and push title matches to top of all fields search. Had to add the title booster expression to the BL config, and add the bf to solr search as part of the search builder, else if the q param isn't there Solr goes all NPE.