### PR TITLE
fix: fix View online URL [BLAC-273]

### DIFF
--- a/app/components/catalogue_record_actions_component.rb
+++ b/app/components/catalogue_record_actions_component.rb
@@ -23,11 +23,9 @@ class CatalogueRecordActionsComponent < ViewComponent::Base
 
   def online_url
     if @document.online_access.present?
-      @document.online_access.first[:href].include?("nla.gov.au")
+      @document.online_access.first[:href]
     elsif @document.copy_access.present?
-      @document.copy_access.first[:href].include?("nla.gov.au")
-    else
-      "#"
+      @document.copy_access.first[:href]
     end
   end
 

--- a/spec/components/catalogue_record_actions_component_spec.rb
+++ b/spec/components/catalogue_record_actions_component_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe CatalogueRecordActionsComponent, type: :component do
 
       render_inline(described_class.new(document: document))
 
-      expect(page.text).to include("View online")
+      expect(page).to have_link("View online", href: "https://nla.gov.au/nla.obj-123456789")
     end
 
     context "when the document is audio" do
@@ -64,7 +64,7 @@ RSpec.describe CatalogueRecordActionsComponent, type: :component do
 
         render_inline(described_class.new(document: document))
 
-        expect(page.text).to include("Listen")
+        expect(page).to have_link("Listen", href: "https://nla.gov.au/nla.obj-123456789")
       end
     end
   end


### PR DESCRIPTION
Copy + paste mistake. Should use the `href` value, rather than checking if it includes "nla.gov.au".