### PR TITLE
fix: missing sidebar

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -44,6 +44,8 @@ module ApplicationHelper
   def is_excluded_blacklight_searchbar_display_path?
     if (current_page?(root_path) || current_page?(search_catalog_path)) && !has_search_parameters?
       true
+    elsif current_page?(advanced_search_catalog_path)
+      true
     else
       current_page?(bento_search_index_path)
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -58,6 +58,8 @@ module ApplicationHelper
       has_search_parameters?
     elsif !current_page?(root_path)
       true
+    elsif current_page?(root_path)
+      has_search_parameters?
     else
       false
     end


### PR DESCRIPTION
Sidebar should only be shown on catalogue pages, but because the `root_url` is also the catalogue controller index route, it is also accessible without having `/catalogue` in the URL path.

I hate routes!
![image](https://github.com/nla/nla-blacklight/assets/12688/74af0ade-7bd4-49b8-ac0b-95233bcd044c)
