### PR TITLE
feat!: create separate home page from catalog [BLAC-286]

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,0 +1,4 @@
+class StaticPagesController < ApplicationController
+  def home
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,30 +41,19 @@ module ApplicationHelper
     result
   end
 
-  def is_excluded_blacklight_searchbar_display_path?
-    if (current_page?(root_path) || current_page?(search_catalog_path)) && !has_search_parameters?
-      true
-    elsif current_page?(advanced_search_catalog_path)
-      true
-    else
-      current_page?(bento_search_index_path)
-    end
+  def show_search_bar?
+    !current_page?(root_path) && !current_page?(advanced_search_catalog_path) && !current_page?(bento_search_index_path)
   end
 
   # This will exclude displaying the global message on the home page because the
   # GlobalMessageComponent is displayed inside the _home_text.html.erb template and would cause
   # the message to be displayed twice.
-  def display_global_message_on_page?
-    # !current_page?(root_path) && (current_page?(search_catalog_path) && has_search_parameters?)
-    if current_page?(search_catalog_path)
-      has_search_parameters?
-    elsif !current_page?(root_path)
-      true
-    elsif current_page?(root_path)
-      has_search_parameters?
-    else
-      false
-    end
+  def show_global_message?
+    !current_page?(root_path)
+  end
+
+  def show_facets_sidebar?
+    !current_page?(root_path)
   end
 
   private

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -7,7 +7,7 @@ module LayoutHelper
   # Classes used for sizing the main content of a Blacklight page
   # @return [String]
   def main_content_classes
-    if display_global_message_on_page?
+    if show_facets_sidebar?
       "col-md-8 col-lg-9"
     else
       "col-12"

--- a/app/helpers/single_search_helper.rb
+++ b/app/helpers/single_search_helper.rb
@@ -46,7 +46,7 @@ module SingleSearchHelper
       fa_base_url = ENV["FINDING_AIDS_SEARCH_URL"].chomp("/catalog.json")
       "#{fa_base_url}?group=false&search_field=all_fields&q=#{bento_query}"
     else
-      "#{root_url}?search_field=all_fields&q=#{bento_query}"
+      "#{search_catalog_url}?search_field=all_fields&q=#{bento_query}"
     end
 
     ss_uri_encode(link)
@@ -54,7 +54,7 @@ module SingleSearchHelper
 
   def advanced_search_link(key, query)
     qp2 = "all_fields=#{ss_uri_encode(query).gsub("&", "%26")}&search_field=advanced"
-    "#{root_url}advanced?#{qp2}"
+    "#{advanced_search_catalog_url}?#{qp2}"
   end
 
   def is_catalogued?(url)

--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -4,11 +4,11 @@
       <%= yield %>
     </section>
 
-    <% if display_global_message_on_page? %>
+    <%# if show_facets_sidebar? %>
         <section id="sidebar" class="<%= sidebar_classes %> mt-5" aria-label="<%= t('blacklight.search.documents.aria.limit_search') %>">
           <%= content_for(:sidebar) %>
         </section>
-    <% end %>
+    <%# end %>
   <% else %>
     <section class="col-md-12">
       <%= yield %>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -44,14 +44,11 @@
       <%= link_to t('blacklight.skip_links.main_content'), '#main-container', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
       <%= content_for(:skip_links) %>
     </nav>
+
     <%= render partial: 'shared/header_navbar' %>
 
     <main id="main-container" class="<%= container_classes %>" role="main" aria-label="<%= t('blacklight.main.aria.main_container') %>">
       <%= content_for(:container_header) %>
-
-      <% if display_global_message_on_page? %>
-        <%= render GlobalMessageComponent.new %>
-      <% end %>
 
       <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
 

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -11,7 +11,13 @@
   </div>
 </header>
 
-<% unless is_excluded_blacklight_searchbar_display_path? %>
+<% if show_global_message? %>
+  <div class="<%= container_classes %>">
+    <%= render GlobalMessageComponent.new %>
+  </div>
+<% end %>
+
+<% if show_search_bar? %>
 <div class="navbar-search navbar navbar-light bg-light">
   <div class="<%= container_classes %>">
     <%= render_search_bar %>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,3 +1,10 @@
+<section class="collection-search mb-5">
+  <p class="h5 mb-3"><%= t('blacklight.collection_search.description') %></p>
+  <div class="collection-search-box px-4 py-5">
+    <h2><%= t('blacklight.collection_search.title') %></h2>
+    <%= render "single_search/home_search_form" %>
+  </div>
+</section>
 <div class="card-deck">
   <section class="card eresources-search">
     <div class="image-container"><%= image_tag "eresources.jpg", class: "card-img-top", alt: "Lady using computer" %></div>
@@ -30,10 +37,10 @@
 
 <%# This is the same panel shown in the Rails welcome template %>
 <% if Rails.env.development? || Rails.env.test? %>
-<div id="about" class="card">
-  <h6 class="card-header collapsed collapse-toggle" data-toggle="collapse" data-target="#about-content"><a href="/rails/info/properties">About this application environment</a></h6>
-  <div id="about-content" class="card-body collapse"></div>
-</div>
+  <div id="about" class="card">
+    <h6 class="card-header collapsed collapse-toggle" data-toggle="collapse" data-target="#about-content"><a href="/rails/info/properties">About this application environment</a></h6>
+    <div id="about-content" class="card-body collapse"></div>
+  </div>
 <% end %>
 
 <script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,5 +40,5 @@ Rails.application.routes.draw do
   get "/500", to: "errors#internal_server"
   get "/503", to: "errors#unavailable"
 
-  root to: "catalog#index"
+  root to: "static_pages#home"
 end

--- a/spec/helpers/single_search_helper_spec.rb
+++ b/spec/helpers/single_search_helper_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe SingleSearchHelper do
 
   describe "#advanced_search_link" do
     it "returns a link to the advanced search page" do
-      expect(helper.advanced_search_link("catalogue", "hello")).to eq("http://test.host/advanced?all_fields=hello&search_field=advanced")
+      expect(helper.advanced_search_link("catalogue", "hello")).to eq("http://test.host/catalog/advanced?all_fields=hello&search_field=advanced")
     end
   end
 
@@ -100,7 +100,7 @@ RSpec.describe SingleSearchHelper do
       end
 
       it "returns a link to the catalogue search results page" do
-        expect(helper.bento_all_results_link("catalogue")).to eq("http://test.host/?search_field=all_fields&q=hello")
+        expect(helper.bento_all_results_link("catalogue")).to eq("http://test.host/catalog?search_field=all_fields&q=hello")
       end
 
       it "returns a link to the finding aids search results page" do
@@ -118,7 +118,7 @@ RSpec.describe SingleSearchHelper do
 
     context "when a query is not present" do
       it "returns a link to the catalogue search results page" do
-        expect(helper.bento_all_results_link("catalogue")).to eq("http://test.host/?search_field=all_fields&q=")
+        expect(helper.bento_all_results_link("catalogue")).to eq("http://test.host/catalog?search_field=all_fields&q=")
       end
 
       it "returns a link to the finding aids search results page" do

--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe "StaticPages" do
+  describe "GET /home" do
+    it "returns http success" do
+      get "/"
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("Search our collections")
+    end
+  end
+end


### PR DESCRIPTION
Creates a new controller for static pages and updates the root path/URL to point to a static home page instead of the catalogue index.

This makes it easier to logically target the home page without having to check if the current path is also the catalogue index.