### PR TITLE
fix: fixes broken copies direct link in copyright [BLAC-291]

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -35,6 +35,7 @@ SimpleCov.start "rails" do
 
   # temporarily filter out bento search classes
   add_filter "app/item_decorators/bento_search/ebsco_eds_article_decorator.rb"
+  add_filter "app/search_engines/bento_search/ebsco_eds_engine.rb"
 
   add_group "Components", "app/components"
   add_group "Presenters", "app/presenters"

--- a/app/components/catalogue_record_actions_component.html.erb
+++ b/app/components/catalogue_record_actions_component.html.erb
@@ -9,7 +9,3 @@
     <%= link_to "Order a copy", "javascript:;", class: "btn btn-primary mb-2 mr-4", onclick: "document.getElementById('copiesdirect_addcart').submit();".html_safe %>
   </div>
 </div>
-<form action="<%= ENV["COPIES_DIRECT_URL"] %>/items/import" class="sr-only" id="copiesdirect_addcart" method="post">
-  <input id="source" name="source" type="hidden" value="cat">
-  <input id="sourcevalue" name="sourcevalue" type="hidden" value="<%= @document.id %>">
-</form>

--- a/app/components/copies_direct_order_form_component.html.erb
+++ b/app/components/copies_direct_order_form_component.html.erb
@@ -1,0 +1,4 @@
+<form action="<%= ENV["COPIES_DIRECT_URL"] %>/items/import" class="sr-only" id="copiesdirect_addcart" method="post">
+  <input id="source" name="source" type="hidden" value="cat">
+  <input id="sourcevalue" name="sourcevalue" type="hidden" value="<%= @document.id %>">
+</form>

--- a/app/components/copies_direct_order_form_component.rb
+++ b/app/components/copies_direct_order_form_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CopiesDirectOrderFormComponent < ViewComponent::Base
+  def initialize(document:)
+    @document = document
+  end
+end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -67,11 +67,12 @@ class CatalogController < ApplicationController
     config.show.title_field = "title_tsim"
     config.show.display_type_field = "format"
 
-    # scxxx Thumbnails
+    # configure additional partials for the document/show view
     config.show.thumbnail_field = "thumbnail_path_ss"
     config.show.thumbnail_presenter = NlaThumbnailPresenter
     config.show.partials.insert(1, :thumbnail) # thumbnail after show_header
-    config.show.partials.insert(2, :catalogue_record_actions) # request_actions after thumbnail
+    config.show.partials.insert(2, :copies_direct_form) # used in Copyright and by "Order a copy" action button
+    config.show.partials.insert(3, :catalogue_record_actions) # request_actions after copies_direct_form
     config.show.partials << :request_item
 
     # solr fields that will be treated as facets by the blacklight application

--- a/app/views/catalog/_copies_direct_form.html.erb
+++ b/app/views/catalog/_copies_direct_form.html.erb
@@ -1,0 +1,1 @@
+<%= render CopiesDirectOrderFormComponent.new(document: document) %>

--- a/spec/components/copies_direct_order_form_component_spec.rb
+++ b/spec/components/copies_direct_order_form_component_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CopiesDirectOrderFormComponent, type: :component do
+  let(:document) { SolrDocument.new(marc_ss: sample_marc, id: 4157485, format: ["Picture"]) }
+
+  it "renders the Copies Direct form" do
+    render_inline(described_class.new(document: document))
+
+    expect(page).to have_css("#copiesdirect_addcart")
+  end
+
+  def sample_marc
+    load_marc_from_file 4157458
+  end
+end

--- a/spec/helpers/layout_helper_spec.rb
+++ b/spec/helpers/layout_helper_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe LayoutHelper do
+  let(:document) { SolrDocument.new(marc_ss: sample_marc) }
+
+  describe "#main_content_classes" do
+    context "when on the home page" do
+      before do
+        allow(helper).to receive(:current_page?).with(root_path).and_return(true)
+      end
+
+      it "returns full width classes" do
+        expect(helper.main_content_classes).to eq("col-12")
+      end
+    end
+
+    context "when not on the home page" do
+      before do
+        allow(helper).to receive(:current_page?).with(root_path).and_return(false)
+      end
+
+      it "returns sidebar width classes" do
+        expect(helper.main_content_classes).to eq("col-md-8 col-lg-9")
+      end
+    end
+  end
+
+  def sample_marc
+    "<record>
+      <leader>01182pam a22003014a 4500</leader>
+      <controlfield tag='001'>a4802615</controlfield>
+      <controlfield tag='003'>SIRSI</controlfield>
+      <controlfield tag='008'>020828s2003    enkaf    b    001 0 eng  </controlfield>
+      <datafield tag='245' ind1='0' ind2='0'>
+        <subfield code='a'>Apples :</subfield>
+        <subfield code='b'>botany, production, and uses /</subfield>
+        <subfield code='c'>edited by D.C. Ferree and I.J. Warrington.</subfield>
+      </datafield>
+      <datafield tag='260' ind1=' ' ind2=' '>
+        <subfield code='a'>Oxon, U.K. ;</subfield>
+        <subfield code='a'>Cambridge, MA :</subfield>
+        <subfield code='b'>CABI Pub.,</subfield>
+        <subfield code='c'>c2003.</subfield>
+      </datafield>
+      <datafield tag='700' ind1='1' ind2=' '>
+        <subfield code='a'>Ferree, David C.</subfield>
+        <subfield code='q'>(David Curtis),</subfield>
+        <subfield code='d'>1943-</subfield>
+      </datafield>
+      <datafield tag='700' ind1='1' ind2=' '>
+        <subfield code='a'>Warrington, I. J.</subfield>
+        <subfield code='q'>(Ian J.)</subfield>
+      </datafield>
+    </record>"
+  end
+end


### PR DESCRIPTION
Moves Copies Direct form to a component separate from the document actions component, so it can be included in the document/show view all the time.

Also added a spec to verify the behavior of the `LayoutHelper#main_content_classes`.