### PR TITLE
fix: correctly encode apostrophe and other HTML entities in title

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+require "htmlentities"
+
 module BlacklightHelper
   include Blacklight::BlacklightHelperBehavior
 
@@ -34,7 +38,9 @@ module BlacklightHelper
     tag = options.fetch(:tag, :h4)
     document ||= @document
 
-    content_tag(tag, document_presenter(document).heading, itemprop: "name", class: "h3")
+    # the content_tag will escape special characters as HTML entities again, so we need to decode them first
+    clean_heading = HTMLEntities.new.decode(document_presenter(document).heading)
+    content_tag(tag, clean_heading, itemprop: "name", class: "h3")
   end
   deprecation_deprecate render_document_heading: "Removed without replacement"
   # rubocop:enable Rails/HelperInstanceVariable

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -30,4 +30,49 @@ RSpec.describe BlacklightHelper do
       end
     end
   end
+
+  describe "#render_document_heading" do
+    let(:document) { SolrDocument.new(marc_ss: sample_marc) }
+
+    context "when apostrophes are present as HTML entities" do
+      before do
+        # rubocop:disable RSpec/VerifiedDoubles
+        allow(helper).to receive(:presenter).and_return(double(heading: "Mayor&#39;s Stone"))
+        # rubocop:enable RSpec/VerifiedDoubles
+      end
+
+      it "converts them to standard apostrophes" do
+        expect(helper.render_document_heading).to eq "<h4 itemprop=\"name\" class=\"h3\">Mayor&#39;s Stone</h4>"
+      end
+    end
+  end
+
+  def sample_marc
+    "<record>
+      <leader>01182pam a22003014a 4500</leader>
+      <controlfield tag='001'>a4802615</controlfield>
+      <controlfield tag='003'>SIRSI</controlfield>
+      <controlfield tag='008'>020828s2003    enkaf    b    001 0 eng  </controlfield>
+      <datafield tag='245' ind1='0' ind2='0'>
+        <subfield code='a'>Apples :</subfield>
+        <subfield code='b'>botany, production, and uses /</subfield>
+        <subfield code='c'>edited by D.C. Ferree and I.J. Warrington.</subfield>
+      </datafield>
+      <datafield tag='260' ind1=' ' ind2=' '>
+        <subfield code='a'>Oxon, U.K. ;</subfield>
+        <subfield code='a'>Cambridge, MA :</subfield>
+        <subfield code='b'>CABI Pub.,</subfield>
+        <subfield code='c'>c2003.</subfield>
+      </datafield>
+      <datafield tag='700' ind1='1' ind2=' '>
+        <subfield code='a'>Ferree, David C.</subfield>
+        <subfield code='q'>(David Curtis),</subfield>
+        <subfield code='d'>1943-</subfield>
+      </datafield>
+      <datafield tag='700' ind1='1' ind2=' '>
+        <subfield code='a'>Warrington, I. J.</subfield>
+        <subfield code='q'>(Ian J.)</subfield>
+      </datafield>
+    </record>"
+  end
 end


### PR DESCRIPTION
The `#content_tag` performs encoding of apostrophes and special characters by default when constructing a tag, so it needs to be escaped first, otherwise it will just return the HTML entity as regular text.

`#render_document_heading` is a deprecated method, so I really don't like changing it to fix this. In Blacklight 8, the document is rendered in a view component, so this will definitely have to be re-implemented in the future.