### PR TITLE
feat: truncate titles to 175 characters on index search page

### DIFF
--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module UrlHelper
+  include Blacklight::UrlHelperBehavior
+
+  def link_to_document(doc, field_or_opts = nil, opts = {counter: nil})
+    label = case field_or_opts
+    when NilClass
+      document_presenter(doc).heading
+    when Hash
+      opts = field_or_opts
+      document_presenter(doc).heading
+    when Proc, Symbol
+      Deprecation.warn(self, "passing a #{field_or_opts.class} to link_to_document is deprecated and will be removed in Blacklight 8")
+      Deprecation.silence(Blacklight::IndexPresenter) do
+        index_presenter(doc).label field_or_opts, opts
+      end
+    else # String
+      field_or_opts
+    end
+
+    if current_page?(search_catalog_path)
+      label = label.truncate(175, separator: " ")
+    end
+
+    Deprecation.silence(Blacklight::UrlHelperBehavior) do
+      link_to label, url_for_document(doc), document_link_params(doc, opts)
+    end
+  end
+end


### PR DESCRIPTION
Overrides the `Blacklight::UrlHelperBehavior#link_to_document` method to truncate the title on the search results index page.