### PR TITLE
fix: EDS bento perf

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -11,7 +11,7 @@ class SearchController < ApplicationController
 
       @cat_per_page = params["cat_per_page"] || 10
       @eds_per_page = params["eds_per_page"] || 3
-      @fa_per_page = params["fa_per_page"] || 3
+      @fa_per_page = params["fa_per_page"] || 5
 
       @results = {}
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "benchmark"
+
 class SearchController < ApplicationController
   include BentoQueryConcern
 
@@ -9,12 +11,16 @@ class SearchController < ApplicationController
 
       @cat_per_page = params["cat_per_page"] || 10
       @eds_per_page = params["eds_per_page"] || 3
-      @fa_per_page = params["fa_per_page"] || 10
+      @fa_per_page = params["fa_per_page"] || 3
 
       @results = {}
 
-      @results["catalogue"] = BentoSearch.get_engine(:catalogue).search(@query, per_page: @cat_per_page)
-      @results["finding_aids"] = BentoSearch.get_engine(:finding_aids).search(@query, per_page: @fa_per_page)
+      Benchmark.bm do |x|
+        x.report("catalogue") { @results["catalogue"] = BentoSearch.get_engine(:catalogue).search(@query, per_page: @cat_per_page) }
+        x.report("ebsco_eds_keyword") { @results["ebsco_eds_keyword"] = BentoSearch.get_engine(:ebsco_eds_keyword).search(@query, per_page: @eds_per_page) }
+        x.report("ebsco_eds_title") { @results["ebsco_eds_title"] = BentoSearch.get_engine(:ebsco_eds_title).search(@query, per_page: @eds_per_page) }
+        x.report("finding_aids") { @results["finding_aids"] = BentoSearch.get_engine(:finding_aids).search(@query, per_page: @fa_per_page) }
+      end
     end
 
     @total_results = 0

--- a/app/search_engines/bento_search/ebsco_eds_engine.rb
+++ b/app/search_engines/bento_search/ebsco_eds_engine.rb
@@ -39,7 +39,6 @@ class BentoSearch::EbscoEdsEngine
       results.total_items = 0
       return results
     end
-    required_hit_count = args[:per_page].present? ? [args[:per_page], 1].max : 1
     per_page = args[:per_page]
 
     query = if configuration[:query_prefix].present?
@@ -55,79 +54,48 @@ class BentoSearch::EbscoEdsEngine
 
     response = session.search(sq)
     total_hits = response.stat_total_hits
-    total_tested_hits = [response.stat_total_hits.to_i, 100].min
 
     results.total_items = total_hits.to_i
 
-    catch :enough_hits do
-      found = 0
-      max_page = (total_tested_hits / per_page).ceil
-      (0..max_page).each { |p|
-        sq = {
-          query: q,
-          page: p,
-          results_per_page: per_page
-        }
+    response.records.each do |rec|
+      item = BentoSearch::ResultItem.new
+      item.link_is_fulltext = true
 
-        response = session.search(sq, add_actions: true)
+      item.title = (rec.eds_title.presence || I18n.t("bento_search.eds.record_not_available"))
+      item.title = prepare_ebsco_eds_payload(item.title, true)
 
-        response.records.each do |rec|
-          # duplicates creep in unless
-          found_already = false
-          results.each do |check|
-            if check.unique_id == rec.id
-              found_already = true
-              break
-            end
-          end
-          next if found_already
+      item.abstract = rec.eds_abstract
+      item.abstract = prepare_ebsco_eds_payload(item.abstract, true)
 
-          found += 1
-          if required_hit_count.present?
-            throw :enough_hits if found > required_hit_count
-          elsif found > 1
-            throw :enough_hits
-          end
+      item.unique_id = rec.id
+      authors = rec.eds_authors
+      authors.each do |author|
+        item.authors << BentoSearch::Author.new(display: author)
+      end
+      item.link = rec.eds_plink
 
-          item = BentoSearch::ResultItem.new
-          item.link_is_fulltext = true
-
-          item.title = (rec.eds_title.presence || I18n.t("bento_search.eds.record_not_available"))
-          item.title = prepare_ebsco_eds_payload(item.title, true)
-
-          item.abstract = rec.eds_abstract
-          item.abstract = prepare_ebsco_eds_payload(item.abstract, true)
-
-          item.unique_id = rec.id
-          authors = rec.eds_authors
-          authors.each do |author|
-            item.authors << BentoSearch::Author.new(display: author)
-          end
-          item.link = rec.eds_plink
-
-          item.format_str = rec.eds_publication_type
-          item.doi = rec.eds_document_doi
-          if rec.eds_page_start.present?
-            item.start_page = rec.eds_page_start.to_s
-            if rec.eds_page_count.present?
-              item.end_page = (rec.eds_page_start.to_i + rec.eds_page_count.to_i - 1).to_s
-            end
-          end
-          date = rec.eds_publication_date
-          if date.present?
-            ymd = date.split("-").map(&:to_i)
-            item.publication_date = Date.new(ymd[0], ymd[1], ymd[2])
-          end
-          year = rec.eds_publication_year
-          if year.present?
-            item.year = year
-          end
-          item.source_title = rec.eds_source_title
-          item.volume = rec.eds_volume
-          results << item
+      item.format_str = rec.eds_publication_type
+      item.doi = rec.eds_document_doi
+      if rec.eds_page_start.present?
+        item.start_page = rec.eds_page_start.to_s
+        if rec.eds_page_count.present?
+          item.end_page = (rec.eds_page_start.to_i + rec.eds_page_count.to_i - 1).to_s
         end
-      }
-    end # enough hits already
+      end
+      date = rec.eds_publication_date
+      if date.present?
+        ymd = date.split("-").map(&:to_i)
+        item.publication_date = Date.new(ymd[0], ymd[1], ymd[2])
+      end
+      year = rec.eds_publication_year
+      if year.present?
+        item.year = year
+      end
+      item.source_title = rec.eds_source_title
+      item.volume = rec.eds_volume
+      results << item
+    end
+
     results
   end
 

--- a/app/views/bento_search/_item_title.html.erb
+++ b/app/views/bento_search/_item_title.html.erb
@@ -24,7 +24,7 @@
         <%= index %>.
       <% end %>
     <% end %>
-    <%= link_to_unless(item.link.blank?, item.complete_title, item.link) %>
+    <%= link_to_unless(item.link.blank?, item.complete_title.truncate(175, separator: " "), item.link) %>
 
     <% if item.display_language.present? %>
 

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -215,7 +215,7 @@ RSpec.configure do |config|
 
     fa_search = IO.read("spec/files/bento_search/fa_search.json")
 
-    WebMock.stub_request(:get, "http://test.host/finding-aids/catalog.json?per_page=10&q=hydrogen")
+    WebMock.stub_request(:get, "http://test.host/finding-aids/catalog.json?per_page=5&q=hydrogen")
       .with(
         headers: {
           "Accept" => "*/*",


### PR DESCRIPTION
Ripped out original Cornell code to make the response faster. Also truncate the linked titles to match the catalogue search results titles.