### PR TITLE
fix: display of global message on home page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -49,7 +49,7 @@ module ApplicationHelper
   # GlobalMessageComponent is displayed inside the _home_text.html.erb template and would cause
   # the message to be displayed twice.
   def show_global_message?
-    !current_page?(root_path)
+    !current_page?(search_catalog_path)
   end
 
   def show_facets_sidebar?

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -1,3 +1,5 @@
+<%= render GlobalMessageComponent.new %>
+
 <div class="card-deck">
   <section class="card eresources-search">
     <div class="image-container"><%= image_tag "eresources.jpg", class: "card-img-top", alt: "Lady using computer" %></div>


### PR DESCRIPTION
The global message was missing from the home page after I restructured the application root route to not point to the catalogue search index page.