### PR TITLE
feat: delivery information

### DIFF
--- a/app/views/request/create.html.erb
+++ b/app/views/request/create.html.erb
@@ -1,10 +1,9 @@
 <h1><%= t("requesting.success.heading") %></h1>
 <h2 class="mt-4"><%= @document.first("title_tsim") %></h2>
 
-<%# TODO: BLAC-275 %>
-<!--<div class="row">-->
-<!--  <p class="col-12 col-lg-8"><%#= t("requesting.success.message", title: @document.first("title_tsim")).html_safe %></p>-->
-<!--</div>-->
+<div class="row">
+  <p class="col-12 col-lg-8"><%= t("requesting.success.message", title: @document.first("title_tsim")).html_safe %></p>
+</div>
 
 <div class="row mt-4">
   <div class="col-12">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,7 +56,7 @@ en:
     message: "Request this item to view in the Library's reading room using your library card."
     success:
       heading: "Request complete"
-      message: "Your request for <strong>%{title}</strong> is currently being processed and will be available for collection from 9am Monday."
+      message: 'Your request for <strong>%{title}</strong> is currently being processed. Check our <a href="https://www.nla.gov.au/using-library/collection-delivery-service/collection-delivery-times">collection delivery times</a>.'
     metadata:
       item_requested: "Item Requested:"
       collect_from: "Collect From:"

--- a/spec/helpers/request_helper_spec.rb
+++ b/spec/helpers/request_helper_spec.rb
@@ -74,6 +74,58 @@ RSpec.describe RequestHelper do
     end
   end
 
+  describe "#pickup_location_text" do
+    context "when the pickup location starts with 'MRR'" do
+      let(:item) { {"pickupLocation" => {"code" => "MRR-SP"}} }
+
+      it "returns the Main Reading Room pickup location text" do
+        expect(pickup_location_text(item)).to include "Main Reading Room"
+      end
+    end
+
+    context "when the pickup location starts with 'NMRR'" do
+      let(:item) { {"pickupLocation" => {"code" => "NMRR-SP"}} }
+
+      it "returns the Newspapers and Family History pickup location text" do
+        expect(pickup_location_text(item)).to include "Newspapers and Family History"
+      end
+    end
+
+    context "when the pickup location starts with 'SCRR'" do
+      let(:item) { {"pickupLocation" => {"code" => "SCRR-SP"}} }
+
+      it "returns the Special Collections Reading Room pickup location text" do
+        expect(pickup_location_text(item)).to include "Special Collections Reading Room"
+      end
+    end
+  end
+
+  describe "#pickup_location_img" do
+    context "when the pickup location starts with 'MRR'" do
+      let(:item) { {"pickupLocation" => {"code" => "MRR-SP"}} }
+
+      it "returns the Main Reading Room image" do
+        expect(pickup_location_img(item)).to include "main_reading_room.jpeg"
+      end
+    end
+
+    context "when the pickup location starts with 'NMRR'" do
+      let(:item) { {"pickupLocation" => {"code" => "NMRR-SP"}} }
+
+      it "returns the Newspapers and Family History image" do
+        expect(pickup_location_img(item)).to include "newspapers_and_family_history_zone.jpg"
+      end
+    end
+
+    context "when the pickup location starts with 'SCRR'" do
+      let(:item) { {"pickupLocation" => {"code" => "SCRR-SP"}} }
+
+      it "returns the Special Collections Reading Room image" do
+        expect(pickup_location_img(item)).to include "special_collections.jpeg"
+      end
+    end
+  end
+
   def holdings_response
     JSON.parse(IO.read("spec/files/catalogue_services/serial.json"))
   end

--- a/spec/requests/request_spec.rb
+++ b/spec/requests/request_spec.rb
@@ -118,13 +118,6 @@ RSpec.describe "Requests" do
     end
   end
 
-  # describe "GET /show" do
-  #   it "returns http success" do
-  #     get "/catalog/1414519/request/show"
-  #     expect(response).to have_http_status(:success)
-  #   end
-  # end
-
   def serial_marc
     load_marc_from_file 1595553
   end

--- a/spec/requests/request_spec.rb
+++ b/spec/requests/request_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Requests" do
   let(:instance_id) { "08aed703-3648-54d0-80ef-fddb3c635731" }
   let(:holdings_id) { "37fbc2dd-3b37-58b8-b447-b538ba7265b9" }
   let(:item_id) { "60ae1cf9-5b4c-5fac-9a38-2cb195cdb7b2" }
-  let(:document) { SolrDocument.new(id: solr_document_id, marc_ss: serial_marc) }
+  let(:document) { SolrDocument.new(id: solr_document_id, marc_ss: serial_marc, title_tsim: "National Geographic") }
 
   describe "GET /new" do
     context "when requesting a monograph" do
@@ -96,6 +96,7 @@ RSpec.describe "Requests" do
         }
       )
       expect(response).to have_http_status(:success)
+      expect(response.body).to include("Your request for <strong>National Geographic</strong> is currently being processed.")
     end
 
     context "when a catalogue services error occurs" do


### PR DESCRIPTION
Putting some generic delivery information on the success page while waiting for feedback on implementation of BLAC-275