### PR TITLE
fix: fix nil error

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -25,7 +25,8 @@ class SearchController < ApplicationController
 
     @total_results = 0
     @results&.each do |_key, res|
-      @total_results += res.total_items
+      # the EDSEngine might return nil when there's an error, so we need to check for that
+      @total_results += res.total_items.nil? ? 0 : res.total_items
     end
 
     render "single_search/index"

--- a/app/search_engines/bento_search/blacklight_engine.rb
+++ b/app/search_engines/bento_search/blacklight_engine.rb
@@ -84,7 +84,7 @@ module BentoSearch
     # create the URL to the Blacklight API based on normalized search args
     def construct_query(args)
       url = "#{configuration.base_url}?q=#{CGI.escape args[:query]}"
-      url += "&per_page=#{args[:per_page]}a" if args[:per_page]
+      url += "&per_page=#{args[:per_page]}" if args[:per_page]
 
       url
     end


### PR DESCRIPTION
When an error is raised in the bento search engine, it may return a nil value for `total_items`, so we need to check it and make sure to add 0 instead of try to convert to an integer.