### PR TITLE
fix: fixes linking of images on search results page [BLAC-318]

### DIFF
--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -21,12 +21,18 @@ module UrlHelper
     end
     # :nocov:
 
-    if current_page?(search_catalog_path)
-      label = label.truncate(175, separator: " ")
-    end
+    label = truncate_title(label)
 
     Deprecation.silence(Blacklight::UrlHelperBehavior) do
-      link_to label, "url_for_document(doc)", document_link_params(doc, opts)
+      link_to label, url_for_document(doc), document_link_params(doc, opts)
+    end
+  end
+
+  def truncate_title(title)
+    if current_page?(search_catalog_path)
+      title.truncate(175, separator: " ")
+    else
+      title
     end
   end
 end

--- a/app/presenters/nla_thumbnail_presenter.rb
+++ b/app/presenters/nla_thumbnail_presenter.rb
@@ -14,11 +14,10 @@ class NlaThumbnailPresenter < Blacklight::ThumbnailPresenter
     value = thumbnail_value(image_options)
     return value if value.nil? || url_options[:suppress_link]
 
-    context = view_config[:key]
-    if context == :show
-      view_context.link_to value, link_value, {"aria-hidden": true, tabindex: -1, counter: @counter}
+    if is_catalogue_record_page?
+      view_context.link_to value, link_value, url_options
     else
-      view_context.link_to_document document, value, url_options
+      view_context.link_to value, view_context.solr_document_path(document), url_options
     end
   end
   # :nocov:


### PR DESCRIPTION
The image tag would get chopped off because of the truncation logic in `UrlHelper::link_to_document`.

The underlying reason was that the `NlaThumbnailPresenter` should not have been sending the image tag to the `#link_to_document` method in the first place.