### PR TITLE
refactor: move thumbnail cache from page to service

### DIFF
--- a/app/components/blacklight/document/thumbnail_component.html.erb
+++ b/app/components/blacklight/document/thumbnail_component.html.erb
@@ -1,14 +1,12 @@
-<% cache presenter.document.first("id"), expires_in: 1.day do %>
-  <% value = use_thumbnail_tag_behavior? ? presenter.thumbnail.thumbnail_tag(@image_options, 'aria-hidden': true, tabindex: -1, counter: @counter) : presenter.thumbnail.render(@image_options) %>
+<% value = use_thumbnail_tag_behavior? ? presenter.thumbnail.thumbnail_tag(@image_options, 'aria-hidden': true, tabindex: -1, counter: @counter) : presenter.thumbnail.render(@image_options) %>
 
-  <% if value %>
-    <div class="document-thumbnail <%= presenter.thumbnail.is_catalogue_record_page? ? "col-12 col-md-5 mb-3" : "col-4 col-md-2 order-3" %>">
-      <% if use_thumbnail_tag_behavior? %>
-        <% warn_about_deprecated_behavior %>
-        <%= value %>
-      <% else %>
-        <%= helpers.link_to_document(presenter.document, value, 'aria-hidden': true, tabindex: -1, counter: @counter) %>
-      <% end %>
-    </div>
+<% if value %>
+<div class="document-thumbnail <%= presenter.thumbnail.is_catalogue_record_page? ? "col-12 col-md-5 mb-3" : "col-4 col-md-2 order-3" %>">
+  <% if use_thumbnail_tag_behavior? %>
+    <% warn_about_deprecated_behavior %>
+    <%= value %>
+  <% else %>
+    <%= helpers.link_to_document(presenter.document, value, 'aria-hidden': true, tabindex: -1, counter: @counter) %>
   <% end %>
+</div>
 <% end %>

--- a/app/services/catalogue_services_client.rb
+++ b/app/services/catalogue_services_client.rb
@@ -81,14 +81,16 @@ class CatalogueServicesClient
     url += "&lccList=#{lccn_list}" if lccn_list.present?
     url += "&width=#{width}"
 
-    res = conn.get(url)
+    Rails.cache.fetch("thumbnail_#{url}", expires_in: 1.day) do
+      res = conn.get(url)
 
-    if res.status == 200
-      content_type = res.headers["content-type"]
-      "data:#{content_type};base64,#{Base64.encode64(res.body).gsub("\n", "")}"
-    else
-      Rails.logger.debug { "Failed to retrieve thumbnail for #{bib_id}" }
-      nil
+      if res.status == 200
+        content_type = res.headers["content-type"]
+        "data:#{content_type};base64,#{Base64.encode64(res.body).gsub("\n", "")}"
+      else
+        Rails.logger.debug { "Failed to retrieve thumbnail for #{bib_id}" }
+        nil
+      end
     end
   end
 


### PR DESCRIPTION
Pushes the thumbnail cashing to a lower level from the page to the `CatalogueServicesClient`. This takes into account the different sizes between the catalogue search results and the catalogue record page.