### PR TITLE
fix: reformat query string for EDS API

### DIFF
--- a/app/search_engines/bento_search/eds_api_engine.rb
+++ b/app/search_engines/bento_search/eds_api_engine.rb
@@ -7,7 +7,7 @@ module BentoSearch
     def search_implementation(args)
       session = EBSCO::EDS::Session.new({
         caller: "blacklight-bento-search",
-        debug: ENV.fetch("EDS_DEBUG", true),
+        debug: ENV.fetch("EDS_DEBUG", false),
         profile: ENV["EDS_PROFILE"],
         guest: false,
         user: ENV["EDS_USER"],
@@ -29,6 +29,10 @@ module BentoSearch
           highlight: false,
           include_facets: false
         }
+
+        if args[:search_field]
+          sq["search_field"] = args[:search_field]
+        end
 
         response = session.search(sq, add_actions: false)
         total_hits = response.stat_total_hits
@@ -84,13 +88,7 @@ module BentoSearch
     end
 
     def construct_query(args)
-      query = "AND,"
-      if args[:search_field]
-        query += "#{args[:search_field]}:"
-      end
-      # Can't have any commas in query, it turns out, although
-      # this is not documented.
-      query + args[:query].gsub(",", " ")
+      args[:query].gsub(",", " ")
     end
 
     def prepare_ebsco_eds_payload(str, html_safe = false)

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -235,7 +235,7 @@ RSpec.configure do |config|
 
     WebMock.stub_request(:post, /eds-api.ebscohost.com\/edsapi\/rest\/Search/)
       .with(
-        body: "{\"SearchCriteria\":{\"Queries\":[{\"Term\":\"AND,hydrogen\"}],\"SearchMode\":\"bool\",\"IncludeFacets\":\"n\",\"FacetFilters\":[],\"Limiters\":[],\"Sort\":\"relevance\",\"PublicationId\":null,\"RelatedContent\":[\"emp\"],\"AutoSuggest\":\"y\",\"Expanders\":[\"fulltext\"],\"AutoCorrect\":\"n\"},\"RetrievalCriteria\":{\"View\":\"brief\",\"ResultsPerPage\":3,\"PageNumber\":1,\"Highlight\":false,\"IncludeImageQuickView\":false},\"Actions\":[\"GoToPage(1)\"],\"Comment\":\"\"}",
+        body: "{\"SearchCriteria\":{\"Queries\":[{\"Term\":\"hydrogen\"}],\"SearchMode\":\"bool\",\"IncludeFacets\":\"n\",\"FacetFilters\":[],\"Limiters\":[],\"Sort\":\"relevance\",\"PublicationId\":null,\"RelatedContent\":[\"emp\"],\"AutoSuggest\":\"y\",\"Expanders\":[\"fulltext\"],\"AutoCorrect\":\"n\"},\"RetrievalCriteria\":{\"View\":\"brief\",\"ResultsPerPage\":3,\"PageNumber\":1,\"Highlight\":false,\"IncludeImageQuickView\":false},\"Actions\":[\"GoToPage(1)\"],\"Comment\":\"\"}",
         headers: {
           "Accept" => "application/json",
           "X-Authenticationtoken" => "AGPGzYCzk-NO9_ueZr4gxTl-MP2cQWQ1zUR7IkN1c3RvbWVySWQiOiJzODQyMzUxNiIsIkdyb3VwSWQiOiJtYWluIn0",
@@ -248,7 +248,7 @@ RSpec.configure do |config|
 
     WebMock.stub_request(:post, /eds-api.ebscohost.com\/edsapi\/rest\/Search/)
       .with(
-        body: "{\"SearchCriteria\":{\"Queries\":[{\"Term\":\"AND,TI:hydrogen\"}],\"SearchMode\":\"bool\",\"IncludeFacets\":\"n\",\"FacetFilters\":[],\"Limiters\":[],\"Sort\":\"relevance\",\"PublicationId\":null,\"RelatedContent\":[\"emp\"],\"AutoSuggest\":\"y\",\"Expanders\":[\"fulltext\"],\"AutoCorrect\":\"n\"},\"RetrievalCriteria\":{\"View\":\"brief\",\"ResultsPerPage\":3,\"PageNumber\":1,\"Highlight\":false,\"IncludeImageQuickView\":false},\"Actions\":[\"GoToPage(1)\"],\"Comment\":\"\"}",
+        body: "{\"SearchCriteria\":{\"Queries\":[{\"FieldCode\":\"TI\",\"Term\":\"hydrogen\"}],\"SearchMode\":\"bool\",\"IncludeFacets\":\"n\",\"FacetFilters\":[],\"Limiters\":[],\"Sort\":\"relevance\",\"PublicationId\":null,\"RelatedContent\":[\"emp\"],\"AutoSuggest\":\"y\",\"Expanders\":[\"fulltext\"],\"AutoCorrect\":\"n\"},\"RetrievalCriteria\":{\"View\":\"brief\",\"ResultsPerPage\":3,\"PageNumber\":1,\"Highlight\":false,\"IncludeImageQuickView\":false},\"Actions\":[\"GoToPage(1)\"],\"Comment\":\"\"}",
         headers: {
           "Accept" => "application/json",
           "X-Authenticationtoken" => "AGPGzYCzk-NO9_ueZr4gxTl-MP2cQWQ1zUR7IkN1c3RvbWVySWQiOiJzODQyMzUxNiIsIkdyb3VwSWQiOiJtYWluIn0",


### PR DESCRIPTION
This fixes the discrepancy in search results between searching via the EDS live site vs the EDS API gem.

**Cause:**
The gem is unable to parse the query string in the same way the EDS API is able to. According to the EDS API docs, the format `{booleanOperator},{fieldCode}:{term}` is valid. When passing this query string into the EDS API via the gem, it's unable to parse the `{booleanOperator}` and `{fieldCode}` parts of the query string into the appropriate `SearchCriteria` parameters for the request payload. 

See https://github.com/ebsco/edsapi-ruby/blob/6319460d9b76714db64784cfbce8d26b0fd9beba/lib/ebsco/eds/options.rb#L250.

Example search using the query string "AND,TI:hydrogen"

Request payload via edsapi-ruby:
```json
{
  "SearchCriteria": {
    "Queries": [
      {
        "Term": "AND,TI:hydrogen"
      }
    ],
    "SearchMode": "all",
    "IncludeFacets": "n",
    "FacetFilters": [],
    "Limiters": [],
    "Sort": "relevance",
    "PublicationId": null,
    "RelatedContent": [
      "emp"
    ],
    "AutoSuggest": "y",
    "Expanders": [
      "fulltext"
    ],
    "AutoCorrect": "y"
  },
  "RetrievalCriteria": {
    "View": "brief",
    "ResultsPerPage": 3,
    "PageNumber": 1,
    "Highlight": false,
    "IncludeImageQuickView": false
  },
  "Actions": [
    "GoToPage(1)"
  ],
  "Comment": ""
}
```

Request payload via EDA API console:
```json
{
  "SearchCriteria": {
    "Queries": [
      {
        "BooleanOperator": "AND",
        "FieldCode": "TI",
        "Term": "hydrogen"
      }
    ],
    "SearchMode": "all",
    "IncludeFacets": "n",
    "Expanders": [
      "fulltext"
    ],
    "Sort": "relevance",
    "RelatedContent": [
      "emp"
    ],
    "AutoSuggest": "y",
    "AutoCorrect": "y"
  },
  "RetrievalCriteria": {
    "View": "brief",
    "ResultsPerPage": 3,
    "PageNumber": 1,
    "Highlight": "n",
    "IncludeImageQuickView": "n"
  },
  "Actions": null
}
```

**Partial workaround:**
There is a work around for the `{fieldCode}` part of the query string, by passing the value into the "search_field" search option.