### PR TITLE
fix: search page header

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_header) { "Search" } %>
+<% content_for(:page_header) { t("headings.search") } %>
 <div class="row">
   <div class="col-md-12">
     <%= render "search/search_form" %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_header) { "Search" } %>
 <div class="row">
   <div class="col-md-12">
     <%= render "search/search_form" %>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -13,7 +13,7 @@
   </div>
   <div class="navbar navbar-dark bg-dark bottombar">
     <div class="container">
-      <%= t('blacklight.application_name') %>
+      <%= content_for(:page_header) || t('blacklight.application_name') %>
     </div>
   </div>
 </header>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:page_header) { "Search" } %>
+<% content_for(:page_header) {t("headings.search") } %>
 <section class="collection-search mb-5">
   <p class="h5 mb-3"><%= t('blacklight.collection_search.description') %></p>
   <div class="collection-search-box px-4 py-5">

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_header) { "Search" } %>
 <section class="collection-search mb-5">
   <p class="h5 mb-3"><%= t('blacklight.collection_search.description') %></p>
   <div class="collection-search-box px-4 py-5">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,8 @@
 
 en:
   loading: "Loading..."
+  headings:
+    search: "Search"
   collection:
     parent: "This is a collection-level record."
     child: "This record belongs in a collection."


### PR DESCRIPTION
Change the bento search and home page header to "Search" instead of "Catalogue".