### PR TITLE
BLAC-355: remove duplicate content  on catalogue specific  homepage

### DIFF
--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -1,34 +1,5 @@
 <%= render GlobalMessageComponent.new %>
 
-<div class="card-deck">
-  <section class="card eresources-search">
-    <div class="image-container"><%= image_tag "eresources.jpg", class: "card-img-top", alt: "Lady using computer" %></div>
-    <div class="card-body">
-      <h2 class="card-title"><%= link_to t("blacklight.eresources.title"), "https://www.nla.gov.au/eresources", class: "stretched-link" %></h2>
-      <p class="card-text"><%= t('blacklight.eresources.description') %></p>
-    </div>
-  </section>
-  <section class="card finding-aids-search">
-    <div class="image-container"><%= image_tag "finding-aids.jpg", class: "card-img-top", alt: "Trolley with manuscript boxes" %></div>
-    <div class="card-body">
-      <h2 class="card-title"><%= link_to t("blacklight.finding_aids.title"), "/finding-aids", class: "stretched-link" %></h2>
-      <p class="card-text"><%= t('blacklight.finding_aids.description') %></p>
-    </div>
-  </section>
-</div>
-<section class="library-card row no-gutters my-5">
-  <div class="col-xl-6">
-    <div>
-      <%= image_tag "national-library-wattle-card.jpg", class: "w-100", alt: "Library card" %>
-    </div>
-  </div>
-  <div class="col-xl-6 px-3">
-    <h2 class="mt-3"><%= t('blacklight.library_card.title') %></h2>
-    
-    <p><%= t('blacklight.library_card.intro') %></p>
-    <p><%= link_to t("blacklight.library_card.button"), "https://www.nla.gov.au/getalibrarycard/registration", class: "btn btn-outline-secondary arrow-after" %></p>
-  </div>
-</section>
 
 <%# This is the same panel shown in the Rails welcome template %>
 <% if Rails.env.development? || Rails.env.test? %>


### PR DESCRIPTION
Sorry, nuking the content for this is a temporary solution that will force us & reader services to revisit content for this page. Will have to do another PR/Deploy once we've got it finalised.