### PR TITLE
feat: ensure login from bento results redirects back to all search results

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,12 +27,18 @@ class ApplicationController < ActionController::Base
   def storable_location?
     request.get? &&
       is_navigational_format? &&
-      (!is_a?(ThumbnailController) && !is_a?(Users::SessionsController) && !is_a?(Users::OmniauthCallbacksController) && !devise_controller?) &&
+      (is_a_storable_controller_action? && !devise_controller?) &&
       !request.xhr?
   end
-  # :nocov:
 
-  # :nocov:
+  # Some parts of the application are not suitable for storing the location
+  def is_a_storable_controller_action?
+    !is_a?(ThumbnailController) && # ignore lazy loaded thumbnail requests
+      !(is_a?(SearchController) && params[:action] == "single_search") && # ignore single search requests from bento
+      !is_a?(Users::SessionsController) && # ignore login requests
+      !is_a?(Users::OmniauthCallbacksController) # ignore login requests to Keycloak
+  end
+
   def store_user_location!
     # :user is the scope we are authenticating
     store_location_for(:user, request.fullpath)


### PR DESCRIPTION
Each panel in the beto search results page is a separate get request that is rendered in a TurboFrame. this ensures that if a user logs in while they're viewing bento search results, they will not be redirected back to a single engine result, but to all the bento search results.