### PR TITLE
fix: put thumbnails behind feature flag and add rescue to thumbnails

### DIFF
--- a/app/services/catalogue_services_client.rb
+++ b/app/services/catalogue_services_client.rb
@@ -92,6 +92,9 @@ class CatalogueServicesClient
         nil
       end
     end
+  rescue
+    Rails.logger.error "Error fetching thumbnail for #{bib_id}"
+    nil
   end
 
   private

--- a/app/views/catalog/_thumbnail.html.erb
+++ b/app/views/catalog/_thumbnail.html.erb
@@ -1,1 +1,3 @@
-<%= render Blacklight::Document::ThumbnailComponent.new(presenter: document_presenter(document), counter: document_counter_with_offset(document_counter ||= 0)) -%>
+<% if Flipper.enabled?(:thumbnails) %>
+  <%= render Blacklight::Document::ThumbnailComponent.new(presenter: document_presenter(document), counter: document_counter_with_offset(document_counter ||= 0)) -%>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,7 @@ if %w[development test].include? ENV["RAILS_ENV"]
 end
 
 module NlaBlacklight
-  VERSION = "2.0.1"
+  VERSION = "2.0.2"
 
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.


### PR DESCRIPTION
Put thumbnails behind a feature flag that can be turned on and off. Also added a rescue block for the service method that retrieves thumbnails just in case.