### PR TITLE
BLAC-383 change callnumber display field

### DIFF
--- a/app/components/request_item_component.html.erb
+++ b/app/components/request_item_component.html.erb
@@ -19,7 +19,7 @@
 
                     <dt class="col-12 col-lg-4 text-lg-right"><%= t("requesting.metadata.call_number") %></dt>
                     <dd class="col-12 col-lg-8">
-                      <p class="mb-0"><%= item["itemLevelCallNumber"] %>
+                      <p class="mb-0"><%= item["effectiveCallNumberComponents"]["callNumber"] %>
                         <% if item["itemCategory"] == "monograph" && item["enumeration"].present? %>
                           <br>Copy: <%= item["enumeration"] %>
                         <% end %></p>

--- a/app/views/request/new.html.erb
+++ b/app/views/request/new.html.erb
@@ -18,7 +18,7 @@
 
         <dt class="col-12 col-md-3 text-md-right"><%= t("requesting.metadata.call_number") %></dt>
         <dd class="col col-md-9">
-          <p class="mb-0"><%= @request.item["itemLevelCallNumber"] %>
+          <p class="mb-0"><%= @request.item["effectiveCallNumberComponents"]["callNumber"] %>
             <% if @request.item["itemCategory"] == "monograph" && @request.item["enumeration"].present? %>
               <br>Copy: <%= @request.item["enumeration"] %>
             <% end %></p>

--- a/spec/files/catalogue_services/1414519.json
+++ b/spec/files/catalogue_services/1414519.json
@@ -23,9 +23,11 @@
           "id": "565c607a-4a21-5a9c-bc22-370947bb9a7c",
           "holdingsRecordId": "bed76196-e6ed-50d8-b658-ef64ce8ad90e",
           "barcode": "31508009830584",
-          "itemLevelCallNumber": "Nq 363.19262 EXP",
           "effectiveLocationId": "6e569414-0af3-45ba-a919-3a7f5dd09fd9",
           "effectiveLocationDisplayName": "Main Reading Room",
+          "effectiveCallNumberComponents": {
+            "callNumber": "Nq 363.19262 EXP"
+          },
           "status": {
             "name": "Available",
             "date": "2023-03-25T01:49:39.174+00:00"
@@ -50,7 +52,8 @@
           "discoverySuppress": false,
           "requestable": false
         }
-      ]
+      ],
+      "notes": []
     }
   ]
 }

--- a/spec/files/catalogue_services/monograph.json
+++ b/spec/files/catalogue_services/monograph.json
@@ -23,9 +23,11 @@
           "id": "4ea9ee16-5adc-52b3-9f5d-f3849fb1cbf2",
           "holdingsRecordId": "5c4999f0-8b7b-5d1b-8837-a835a9f86eb6",
           "barcode": "990001921402",
-          "itemLevelCallNumber": "N A 823.3 W793cl",
           "effectiveLocationId": "14b466b6-86b3-499b-9ddb-262fa0ac56ce",
           "effectiveLocationDisplayName": "Main Reading Room",
+          "effectiveCallNumberComponents": {
+            "callNumber": "N A 823.3 W793cl"
+          },
           "status": {
             "name": "Available",
             "date": "2023-03-25T01:40:14.177+00:00"
@@ -50,7 +52,8 @@
           "discoverySuppress": false,
           "requestable": true
         }
-      ]
+      ],
+      "notes": []
     },
     {
       "id": "5efa2e80-6620-522b-95a7-6f7f7c8e42b7",
@@ -74,9 +77,11 @@
           "id": "c13f51a6-65fb-5692-83e0-d0f51829ccd4",
           "holdingsRecordId": "5efa2e80-6620-522b-95a7-6f7f7c8e42b7",
           "barcode": "31508005863779",
-          "itemLevelCallNumber": "NL A 823.3 W793cl",
           "effectiveLocationId": "e041308f-c160-48b6-b6e7-cd5d0d582122",
           "effectiveLocationDisplayName": "Main Reading Room",
+          "effectiveCallNumberComponents": {
+            "callNumber": "NL A 823.3 W793cl"
+          },
           "status": {
             "name": "Available",
             "date": "2023-03-25T01:40:14.177+00:00"
@@ -101,7 +106,8 @@
           "discoverySuppress": false,
           "requestable": true
         }
-      ]
+      ],
+      "notes": []
     }
   ]
 }

--- a/spec/files/catalogue_services/serial.json
+++ b/spec/files/catalogue_services/serial.json
@@ -22,9 +22,11 @@
           "id": "60ae1cf9-5b4c-5fac-9a38-2cb195cdb7b2",
           "holdingsRecordId": "37fbc2dd-3b37-58b8-b447-b538ba7265b9",
           "barcode": "31508021167700",
-          "itemLevelCallNumber": "NKA 1132",
           "effectiveLocationId": "7b4822a2-9aa7-442d-8ed5-8da3cc8c01a2",
           "effectiveLocationDisplayName": "Special Collections Reading Room",
+          "effectiveCallNumberComponents": {
+            "callNumber": "NKA 1132"
+          },
           "status": {
             "name": "Available",
             "date": "2023-03-25T02:08:44.151+00:00"
@@ -48,7 +50,8 @@
           "discoverySuppress": false,
           "requestable": true
         }
-      ]
+      ],
+      "notes": []
     },
     {
       "id": "fc59f835-c340-5ea4-978d-4bfe4193cee0",
@@ -71,9 +74,11 @@
           "id": "95d87c3b-ef17-5440-9dbb-befcc2b7670b",
           "holdingsRecordId": "fc59f835-c340-5ea4-978d-4bfe4193cee0",
           "barcode": "31508019674725",
-          "itemLevelCallNumber": "HSW 2071",
           "effectiveLocationId": "4ac9fcf1-8288-41b5-ac14-e15648f97158",
           "effectiveLocationDisplayName": "Special Collections Reading Room",
+          "effectiveCallNumberComponents": {
+            "callNumber": "HSW 2071"
+          },
           "status": {
             "name": "Available",
             "date": "2023-03-25T02:09:52.977+00:00"
@@ -98,7 +103,8 @@
           "discoverySuppress": false,
           "requestable": true
         }
-      ]
+      ],
+      "notes": []
     },
     {
       "id": "44e5936d-0bd9-5df5-a86a-5091d04bd84d",
@@ -121,9 +127,11 @@
         {
           "id": "52209e0d-00bd-5f19-91e8-55e1314ef637",
           "holdingsRecordId": "44e5936d-0bd9-5df5-a86a-5091d04bd84d",
-          "itemLevelCallNumber": "N 919.4 NAT",
           "effectiveLocationId": "14b466b6-86b3-499b-9ddb-262fa0ac56ce",
           "effectiveLocationDisplayName": "Main Reading Room",
+          "effectiveCallNumberComponents": {
+            "callNumber": "N 919.4 NAT"
+          },
           "status": {
             "name": "Available",
             "date": "2023-03-25T02:11:49.217+00:00"
@@ -148,7 +156,8 @@
           "discoverySuppress": false,
           "requestable": true
         }
-      ]
+      ],
+      "notes": []
     },
     {
       "id": "d6c97d9e-dfe6-5faa-9f0b-020b2bddbf8c",
@@ -171,9 +180,11 @@
         {
           "id": "7460acfb-72b9-5dba-9089-603921fb47c7",
           "holdingsRecordId": "d6c97d9e-dfe6-5faa-9f0b-020b2bddbf8c",
-          "itemLevelCallNumber": "NL 919.4 NAT",
           "effectiveLocationId": "e041308f-c160-48b6-b6e7-cd5d0d582122",
           "effectiveLocationDisplayName": "Main Reading Room",
+          "effectiveCallNumberComponents": {
+            "callNumber": "NL 919.4 NAT"
+          },
           "status": {
             "name": "Available",
             "date": "2023-03-25T02:16:38.698+00:00"
@@ -198,7 +209,8 @@
           "discoverySuppress": false,
           "requestable": true
         }
-      ]
+      ],
+      "notes": []
     },
     {
       "id": "fe525746-5142-5b54-8c89-c6ed7a9c6196",
@@ -309,9 +321,11 @@
           "id": "0f17532a-2fcf-5c72-a0c9-751fc459481f",
           "holdingsRecordId": "fe525746-5142-5b54-8c89-c6ed7a9c6196",
           "barcode": "31508002260425",
-          "itemLevelCallNumber": "S 910.5 NAT",
           "effectiveLocationId": "11c74e44-110d-4e53-8418-cf4bad1e314a",
           "effectiveLocationDisplayName": "Main Reading Room - Most pre 2005 held offsite",
+          "effectiveCallNumberComponents": {
+            "callNumber": "S 910.5 NAT"
+          },
           "status": {
             "name": "Available",
             "date": "2023-03-25T01:29:35.005+00:00"
@@ -340,9 +354,11 @@
           "id": "e9d2cf15-a219-565a-8ec1-9bc914364c87",
           "holdingsRecordId": "fe525746-5142-5b54-8c89-c6ed7a9c6196",
           "barcode": "2524166",
-          "itemLevelCallNumber": "S 910.5 NAT",
           "effectiveLocationId": "11c74e44-110d-4e53-8418-cf4bad1e314a",
           "effectiveLocationDisplayName": "Main Reading Room - Most pre 2005 held offsite",
+          "effectiveCallNumberComponents": {
+            "callNumber": "S 910.5 NAT"
+          },
           "status": {
             "name": "Available",
             "date": "2023-03-25T02:23:47.983+00:00"
@@ -369,7 +385,8 @@
           "discoverySuppress": false,
           "requestable": false
         }
-      ]
+      ],
+      "notes": []
     }
   ]
 }


### PR DESCRIPTION
Data Systems said we should use effectiveCallNumberLocation.callNumber rather than itemLevelCallNumber as they are not going to populate the callNumber at item level, this new field is added to the item response by Folio based on holding call number