### PR TITLE
fix: load thumbnails in correct size based on view

### DIFF
--- a/app/components/blacklight/document/thumbnail_component.html.erb
+++ b/app/components/blacklight/document/thumbnail_component.html.erb
@@ -1,7 +1,7 @@
 <% value = use_thumbnail_tag_behavior? ? presenter.thumbnail.thumbnail_tag(@image_options, 'aria-hidden': true, tabindex: -1, counter: @counter) : presenter.thumbnail.render(@image_options) %>
 
 <% if value %>
-<div class="<%= presenter.thumbnail.thumbnail_container_classes %>"
+<div
   data-controller="scroll-reveal"
   data-scroll-reveal-class-value="active show"
   data-scroll-reveal-threshold-value="0"

--- a/app/helpers/thumbnail_helper.rb
+++ b/app/helpers/thumbnail_helper.rb
@@ -8,7 +8,7 @@ module ThumbnailHelper
       nlaObjId: document.first("nlaobjid_ss"),
       isbnList: document.isbn_list.join(","),
       lccnList: document.lccn.join(","),
-      width: thumbnail_image_width
+      width: thumbnail_image_width(document)
     }
 
     thumb_url = thumbnail_service.get_url(service_options)
@@ -17,8 +17,7 @@ module ThumbnailHelper
     end
   end
 
-  def thumbnail_image_width
-    path = Rails.application.routes.recognize_path request.referer
-    (path[:controller] == "catalog" && path[:action] == "show") ? 500 : 123
+  def thumbnail_image_width(document)
+    current_page?(solr_document_path(id: document.id)) ? 500 : 123
   end
 end

--- a/app/presenters/nla_thumbnail_presenter.rb
+++ b/app/presenters/nla_thumbnail_presenter.rb
@@ -22,22 +22,13 @@ class NlaThumbnailPresenter < Blacklight::ThumbnailPresenter
     if is_catalogue_record_page?
       view_context.link_to value, link_value, url_options
     else
-      view_context.link_to value, view_context.solr_document_path(document), url_options
+      view_context.link_to value, view_context.solr_document_path(id: document.id), url_options
     end
   end
   # :nocov:
 
-  # Thumbnail is lazy loaded and rendered by calling the ThumbnailController, instead of it being
-  # immediately loaded and rendered when the catalogue record document is rendered by the CatalogController.
-  # This needs to check the referrer path to determine where the request to load and render the
-  # thumbnail came from; the catalog "index" page or the "show" page.
   def is_catalogue_record_page?
-    path = Rails.application.routes.recognize_path view_context.request.referrer
-    path[:controller] == "catalog" && path[:action] == "show"
-  end
-
-  def thumbnail_container_classes
-    is_catalogue_record_page? ? "ml-3 mr-3" : ""
+    view_context.current_page?(view_context.solr_document_path(id: document.id))
   end
 
   def thumbnail_classes

--- a/app/services/thumbnail_service.rb
+++ b/app/services/thumbnail_service.rb
@@ -7,7 +7,7 @@ class ThumbnailService
     end
 
     url = "/thumbnail-service/thumbnail/url?#{options.to_query}"
-    Rails.cache.fetch("thumb_url_#{url}", expires: 1.year) do
+    Rails.cache.fetch("thumb_url_#{url}", expires: 6.hours) do
       res = conn.get(url)
       if res.status == 200
         res.body["url"]

--- a/app/views/catalog/_thumbnail.html.erb
+++ b/app/views/catalog/_thumbnail.html.erb
@@ -1,6 +1,6 @@
 <%
   container_class = current_page?(solr_document_path(id: document.id)) ? "col-12 col-md-5 mb-3" : "col-4 col-md-2 order-3"
 %>
-<turbo-frame id="<%= document.id %>_thumb" src="<%= thumbnail_path(id: document.id) %>" loading="lazy" class="document-thumbnail <%= container_class %>" target="_top">
-  <%= render partial: "shared/thumbnail_spinner" %>
-</turbo-frame>
+<div id="<%= document.id %>_thumb" class="document-thumbnail <%= container_class %>">
+  <%= render Blacklight::Document::ThumbnailComponent.new(presenter: document_presenter(document), counter: document_counter_with_offset(document_counter ||= 0)) -%>
+</div>

--- a/spec/presenters/nla_thumbnail_presenter_spec.rb
+++ b/spec/presenters/nla_thumbnail_presenter_spec.rb
@@ -81,7 +81,8 @@ RSpec.describe NlaThumbnailPresenter do
       context "when there is no image" do
         it "returns nil" do
           allow(view_context).to receive(:render_thumbnail).and_return(nil)
-          allow(request).to receive(:referrer).with(no_args).and_return("/catalog")
+          allow(view_context).to receive(:solr_document_path).with({id: 123}).and_return("/catalog/#{document.id}")
+          allow(view_context).to receive(:current_page?).with("/catalog/#{document.id}").and_return(false)
 
           expect(presenter.thumbnail_tag).to be_nil
         end
@@ -90,7 +91,8 @@ RSpec.describe NlaThumbnailPresenter do
       context "when there is no link" do
         it "returns an image tag only" do
           allow(view_context).to receive(:render_thumbnail).and_return('<img src="image.png" alt="Work Title" onerror="this.style.display=\'none\'" class="w-100" />')
-          allow(request).to receive(:referrer).with(no_args).and_return("/catalog")
+          allow(view_context).to receive(:solr_document_path).with({id: 123}).and_return("/catalog/#{document.id}")
+          allow(view_context).to receive(:current_page?).with("/catalog/#{document.id}").and_return(false)
 
           expect(presenter.thumbnail_tag.include?("href")).to be false
         end
@@ -99,10 +101,10 @@ RSpec.describe NlaThumbnailPresenter do
       context "when there is a link" do
         it "returns an image tag inside an anchor" do
           allow(view_context).to receive(:render_thumbnail).and_return('<img src="image.png" alt="Work Title" onerror="this.style.display=\'none\'" class="w-100" />')
-          allow(view_context).to receive(:solr_document_path).with(any_args).and_return("/catalog/#{document.id}")
+          allow(view_context).to receive(:current_page?).with("/catalog/#{document.id}").and_return(false)
+          allow(view_context).to receive(:solr_document_path).with({id: 123}).and_return("/catalog/#{document.id}")
           allow(view_context).to receive(:link_to).with(any_args).and_return(%(<a href="/catalog/#{document.id}"><img src="image.png" alt="Work Title" onerror="this.style.display='none'" class="w-100" /></a>))
           allow(document).to receive(:online_access).and_return([{href: "https://example.com"}])
-          allow(request).to receive(:referrer).with(no_args).and_return("/catalog")
 
           expect(presenter.thumbnail_tag.include?("href")).to be true
           expect(presenter.thumbnail_tag.include?("img")).to be true
@@ -123,7 +125,8 @@ RSpec.describe NlaThumbnailPresenter do
           allow(view_context).to receive(:render_thumbnail).and_return('<img src="image.png" alt="Work Title" onerror="this.style.display=\'none\'" class="w-100" />')
           allow(view_context).to receive(:link_to).with(any_args).and_return('<a href="https://example.com"><img src="image.png" alt="Work Title" onerror="this.style.display=\'none\'" class="w-100" /></a>')
           allow(document).to receive(:online_access).and_return([{href: "https://example.com"}])
-          allow(request).to receive(:referrer).with(no_args).and_return("/catalog/#{document.id}")
+          allow(view_context).to receive(:solr_document_path).with({id: 123}).and_return("/catalog/#{document.id}")
+          allow(view_context).to receive(:current_page?).with("/catalog/#{document.id}").and_return(true)
 
           expect(presenter.thumbnail_tag.include?("href")).to be true
           expect(presenter.thumbnail_tag.include?("img")).to be true
@@ -138,7 +141,8 @@ RSpec.describe NlaThumbnailPresenter do
 
     context "when displayed on the index page" do
       it "returns false" do
-        allow(request).to receive(:referrer).with(no_args).and_return("/catalog")
+        allow(view_context).to receive(:solr_document_path).with({id: 123}).and_return("/catalog/123")
+        allow(view_context).to receive(:current_page?).with("/catalog/#{document.id}").and_return(false)
 
         expect(catalogue_page_flag).to be false
       end
@@ -148,8 +152,8 @@ RSpec.describe NlaThumbnailPresenter do
       let(:config) { Blacklight::OpenStructWithHashAccess.new({key: :show, thumbnail_field: :thumbnail_path_ss, title_field: :title_tsim, top_level_config: :show}) }
 
       it "returns true" do
-        allow(request).to receive(:referrer).with(no_args).and_return("/catalog/#{document.id}")
-        allow(view_context).to receive(:request).with(no_args).and_return(request)
+        allow(view_context).to receive(:solr_document_path).with({id: 123}).and_return("/catalog/#{document.id}")
+        allow(view_context).to receive(:current_page?).with("/catalog/#{document.id}").and_return(true)
 
         expect(catalogue_page_flag).to be true
       end


### PR DESCRIPTION
Removing the TurboFrames implementation for now and rolling back to the StimulusJS implementation.

I can't seem to make Turbo stop caching the thumbnail frame when navigating back with the browser back button. The configuration options I've read through in the docs don't seem to be working. 😞 