### PR TITLE
fix: display "no request" message for each type of request

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 
 GIT
   remote: https://github.com/nla/nla-blacklight_common
-  revision: 96ffe164739918be7058d3729b13ce9ce45cadef
+  revision: 808aaf43863a53682d5bbfb445ecd452359624f1
   branch: main
   specs:
     nla-blacklight_common (0.1.2)
@@ -319,7 +319,7 @@ GEM
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
     io-console (0.6.0)
-    irb (1.7.0)
+    irb (1.7.1)
       reline (>= 0.3.0)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
@@ -467,8 +467,9 @@ GEM
       actionpack (>= 5.0.1.rc1)
       actionview (>= 5.0.1.rc1)
       activesupport (>= 5.0.1.rc1)
-    rails-dom-testing (2.0.3)
-      activesupport (>= 4.2.0)
+    rails-dom-testing (2.1.1)
+      activesupport (>= 5.0.0)
+      minitest
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
@@ -613,7 +614,7 @@ GEM
       rubocop-performance (~> 1.18.0)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
-    strong_migrations (1.4.4)
+    strong_migrations (1.5.0)
       activerecord (>= 5.2)
     summon (2.0.5)
       json

--- a/app/components/requests_table_component.html.erb
+++ b/app/components/requests_table_component.html.erb
@@ -1,25 +1,24 @@
 <div class="request-summary table-responsive">
-  <%- if @requests.present? %>
-    <table class="table table-hover table-sm mb-4">
-      <caption><%= @caption %> <span class="badge badge-pill badge-secondary"><%= count %></span></caption>
-      <thead>
-      <tr>
-        <th scope="col"><%= t("account.requests.table_column_headings.title") %></th>
-        <th scope="col"><%= t("account.requests.table_column_headings.location") %></th>
-        <th scope="col"><%= t("account.requests.table_column_headings.notes") %></th>
-        <th scope="col"><%= t("account.requests.table_column_headings.request_date") %></th>
-      </tr>
-      </thead>
-      <tbody>
+  <table class="table table-hover table-sm mb-4">
+    <caption><%= @caption %> <span class="badge badge-pill badge-secondary"><%= count %></span></caption>
+    <%- if @requests.present? %>
+    <thead>
+    <tr>
+      <th scope="col"><%= t("account.requests.table_column_headings.title") %></th>
+      <th scope="col"><%= t("account.requests.table_column_headings.location") %></th>
+      <th scope="col"><%= t("account.requests.table_column_headings.notes") %></th>
+      <th scope="col"><%= t("account.requests.table_column_headings.request_date") %></th>
+    </tr>
+    </thead>
+    <%- end %>
+    <tbody>
+    <%- if @requests.present? %>
       <%= render RequestTableRowComponent.with_collection(@requests) %>
-      </tbody>
-    </table>
-  <%- else %>
-    <table class="table table-hover table-sm mb-4">
-      <caption><%= @caption %> <span class="badge badge-pill badge-secondary"><%= count %></span></caption>
+    <%- elsif @requests.blank? %>
       <tr>
-        <td><%= t("account.requests.no_requests") %></td>
+        <td><%= t("account.requests.no_request_message") %></td>
       </tr>
-    </table>
-  <% end %>
+    <% end %>
+    </tbody>
+  </table>
 </div>

--- a/app/components/requests_table_component.rb
+++ b/app/components/requests_table_component.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class RequestsTableComponent < ViewComponent::Base
-  def initialize(requests, caption)
+  def initialize(requests, caption, no_requests_message = nil)
     @requests = requests
     @caption = caption
+    @no_requests_message = no_requests_message
   end
 
   def count

--- a/app/views/account/requests.html.erb
+++ b/app/views/account/requests.html.erb
@@ -3,8 +3,8 @@
   <%= t("account.requests.num_remaining", count: @requests["numRequestsRemaining"]) %>
 </div>
 
-<%= render RequestsTableComponent.new(@requests["readyForCollection"], t("account.requests.table_headings.ready")) %>
-<%= render RequestsTableComponent.new(@requests["itemsRequested"], t("account.requests.table_headings.requested")) %>
+<%= render RequestsTableComponent.new(@requests["readyForCollection"], t("account.requests.table_headings.ready"), t("account.requests.no_request_message.ready")) %>
+<%= render RequestsTableComponent.new(@requests["itemsRequested"], t("account.requests.table_headings.requested"), t("account.requests.no_request_message.requested")) %>
 <%= render RequestsTableComponent.new(@requests["notAvailable"], t("account.requests.table_headings.not_available")) %>
-<%= render RequestsTableComponent.new(@requests["previousRequests"], t("account.requests.table_headings.previous")) %>
+<%= render RequestsTableComponent.new(@requests["previousRequests"], t("account.requests.table_headings.previous"), t("account.requests.no_request_message.previous")) %>
 

--- a/app/views/shared/_user_util_links.html.erb
+++ b/app/views/shared/_user_util_links.html.erb
@@ -10,9 +10,7 @@
             <%= current_user %>
           </a>
           <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-            <% if Flipper.enabled? :request_summary %>
             <%= link_to t("account.requests.menu"), account_requests_path, class: 'dropdown-item' %>
-            <% end %>
             <%= render partial: "blacklight/nav/bookmark" %>
             <%= link_to t('blacklight.header_links.logout'), destroy_user_session_path, class: 'dropdown-item', method: :delete, data: { turbo_method: :delete } %>
           </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -117,7 +117,7 @@ en:
       heading: "Your Requests"
       menu: "Requests"
       num_remaining: "You can request %{count} more items."
-      no_requests: "There are no items requested."
+      no_request_message: "There are no requests."
       table_headings:
         ready: "Ready for collection"
         requested: "Items requested"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,9 +38,7 @@ Rails.application.routes.draw do
     end
   end
 
-  if Flipper.enabled?(:request_summary)
-    get "/account/requests", to: "account#requests", as: "account_requests"
-  end
+  get "/account/requests", to: "account#requests", as: "account_requests"
 
   get "/thumbnail/:id", to: "thumbnail#thumbnail", as: "thumbnail"
 

--- a/spec/components/requests_table_component_spec.rb
+++ b/spec/components/requests_table_component_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe RequestsTableComponent, type: :component do
     it "renders a message" do
       render_inline(described_class.new([], I18n.t("account.requests.table_headings.ready")))
 
-      expect(page).to have_css("td", text: I18n.t("account.requests.no_requests"))
+      expect(page).to have_css("td", text: I18n.t("account.requests.no_request_message"))
     end
   end
 end


### PR DESCRIPTION
Refactored to display a common message for each table when there are no requests of that type.

This includes the [fix in nla-blacklight_common](https://github.com/nla/nla-blacklight_common/pull/7) for staff request summary.