### PR TITLE
fix: reset search session when coming from bento search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -10,6 +10,8 @@ class CatalogController < ApplicationController
   include BlacklightRangeLimit::ControllerOverride
   include Blacklight::Marc::Catalog
 
+  before_action :reset_search_session, only: [:show]
+
   configure_blacklight do |config|
     # default advanced config values
     config.advanced_search ||= Blacklight::OpenStructWithHashAccess.new
@@ -437,5 +439,13 @@ class CatalogController < ApplicationController
 
     # if all else fails, redirect back to the same catalogue record page
     redirect_to solr_document_path(id: params[:id])
+  end
+
+  def reset_search_session
+    referrer = request.referrer
+    if referrer.present? && referrer.include?("/search?q=")
+      Rails.logger.info "Referrer is #{referrer}, resetting search session."
+      session[:search] = {}
+    end
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -11,23 +11,6 @@ class SearchController < ApplicationController
     q = search_params[:q]
     if q.present?
       @query = q
-      #
-      #   set_per_page
-      #
-      #   @results = {}
-      #
-      #   Benchmark.bm do |x|
-      #     x.report("catalogue") { @results["catalogue"] = BentoSearch.get_engine(:catalogue).search(@query, per_page: @cat_per_page) }
-      #     x.report("ebsco_eds_keyword") { @results["ebsco_eds_keyword"] = BentoSearch.get_engine(:ebsco_eds_keyword).search(@query, per_page: @eds_per_page) }
-      #     x.report("ebsco_eds_title") { @results["ebsco_eds_title"] = BentoSearch.get_engine(:ebsco_eds_title).search(@query, per_page: @eds_per_page, search_field: "TI") }
-      #     x.report("finding_aids") { @results["finding_aids"] = BentoSearch.get_engine(:finding_aids).search(@query, per_page: @fa_per_page) }
-      #   end
-      # end
-      #
-      # @total_results = 0
-      # @results&.each do |_key, res|
-      #   # the search engines may return nil if there is an error, so we need to check for that
-      #   @total_results += res.total_items.nil? ? 0 : res.total_items
     end
   end
 


### PR DESCRIPTION
Normally, going back to search index page will reset the search session. Going directly from a finding aid record to a new bento search circumvents this reset that Blacklight/Arclight performs because it's outside it's provided functionality.

This change checks if the referrer is the bento search before displaying the finding aid record to reset the search session.
