### PR TITLE
feat: redirect old VuFind URLs

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,5 +52,11 @@ Rails.application.routes.draw do
   get "/500", to: "errors#internal_server", as: "internal_server_error"
   get "/503", to: "errors#unavailable", as: "unavailable_error"
 
+  # redirect old VuFind URLs
+  scope :Record do
+    get "/:id", to: redirect("/catalog/%{id}")
+    get "/:id/Offsite", to: redirect { |params, request| "/catalog/#{params[:id]}/offsite?#{request.env["QUERY_STRING"]}" }
+  end
+
   root to: "static_pages#home"
 end

--- a/spec/requests/vufind_redirect_spec.rb
+++ b/spec/requests/vufind_redirect_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Redirect VuFind URLs" do
+  it "redirects /Record/:id to /catalog/:id" do
+    expect(get("/Record/000")).to redirect_to("/catalog/000")
+  end
+
+  it "redirects /Record/:id/Offsite?url= to /catalog/:id/offsite?url=" do
+    expect(get("/Record/000/Offsite?url=https://example.com")).to redirect_to("/catalog/000/offsite?url=https://example.com")
+  end
+end


### PR DESCRIPTION
This change will redirect the following VuFind URL segments to the corresponding Blacklight URL segments:

1.  `/Record/[id]` ---> `/catalog/[id]`

    e.g. Given the VuFind URL `https://catalogue.nla.gov.au/Record/3579167`, it will redirect to `https://catalogue.nla.gov.au/catalog/3579167`. 

    Any query string values after `/Record/[id]` are dropped as they are more than likely not compatible with Blacklight.

2.  `/Record/[id]/Offsite?[query-string]` ---> `/catalog/[id]/Offsite?[query-string]`

