### PR TITLE
fix: thumbnail 404

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -4,7 +4,7 @@ STAFF_SUBNET="200.2.40.0,200.2.41.0,200.2.42.0,200.2.43.0"
 
 BLACKLIGHT_TMP_PATH=./tmp
 DATABASE_URL=mysql2://root:@127.0.0.1:3306/nla_blacklight_test?pool=5
-PATRONS_DB_URL=mysql2://root:@127.0.0.1:3306/nla_blacklight_test?pool=5
+    PATRONS_DB_URL=mysql2://root:@127.0.0.1:3306/nla_blacklight_test?pool=5
 REDIS_URL=redis://127.0.0.1:6379/0
 SOLR_URL=http://solr:8983/solr/blacklight
 

--- a/.env.test
+++ b/.env.test
@@ -4,7 +4,7 @@ STAFF_SUBNET="200.2.40.0,200.2.41.0,200.2.42.0,200.2.43.0"
 
 BLACKLIGHT_TMP_PATH=./tmp
 DATABASE_URL=mysql2://root:@127.0.0.1:3306/nla_blacklight_test?pool=5
-    PATRONS_DB_URL=mysql2://root:@127.0.0.1:3306/nla_blacklight_test?pool=5
+PATRONS_DB_URL=mysql2://root:@127.0.0.1:3306/nla_blacklight_test?pool=5
 REDIS_URL=redis://127.0.0.1:6379/0
 SOLR_URL=http://solr:8983/solr/blacklight
 

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -394,7 +394,8 @@ class SolrDocument
   end
 
   def lccn
-    get_marc_derived_field("010a", options: {alternate_script: false})
+    data = get_marc_derived_field("010a", options: {alternate_script: false})
+    data.map { |d| d.gsub(/\s+/, "") }
   end
 
   def has_eresources?
@@ -425,7 +426,8 @@ class SolrDocument
 
   def clean_isn(isn)
     isn = isn.gsub(/[\s-]+/, '\1')
-    isn.gsub(/^.*?([0-9]+).*?$/, '\1')
+    isn = isn.gsub(/^.*?([0-9]+).*?$/, '\1')
+    isn.gsub(/\s+/, "")
   end
 
   def publication_place

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -458,6 +458,19 @@ RSpec.describe SolrDocument do
     end
   end
 
+  describe "#isbn_list" do
+    context "when there is an ISBN" do
+      subject(:isbn_value) do
+        document = described_class.new(marc_ss: isbn)
+        document.isbn_list
+      end
+
+      it "will return the ISBNs as numbers only" do
+        expect(isbn_value).to eq %w[0855507322 0855507403 1111]
+      end
+    end
+  end
+
   describe "#invalid_isbn" do
     context "when there is an invalid ISBN" do
       subject(:invalid_isbn_value) do
@@ -1597,6 +1610,19 @@ RSpec.describe SolrDocument do
 
       it "will return no other authors" do
         expect(other_authors_value).to eq []
+      end
+    end
+  end
+
+  describe "#lccn" do
+    context "when there is an lccn" do
+      subject(:lccn_value) do
+        document = described_class.new(marc_ss: isbn_format)
+        document.lccn
+      end
+
+      it "returns the lccn as numbers only" do
+        expect(lccn_value).to eq ["2019016276"]
       end
     end
   end


### PR DESCRIPTION
Having spaces in the LCCN (which were then encoded as `+` symbols in the URL) were causing a 404 to be returned from the catalogue-service.

I've made sure all whitespace are removed for ISBNs and LCCNs.