### PR TITLE
feat: clean up code and add enable profiling for prod

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -142,7 +142,10 @@ group :development do
   gem "binding_of_caller"
 
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
-  # gem "rack-mini-profiler"
+  gem "rack-mini-profiler"
+  gem "flamegraph"
+  gem "stackprof"
+  gem "memory_profiler"
 
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,6 +279,7 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
+    flamegraph (0.9.5)
     flipper (0.28.3)
       concurrent-ruby (< 2)
     flipper-active_record (0.28.2)
@@ -376,6 +377,7 @@ GEM
       marc (~> 1.0)
     marcel (1.0.2)
     matrix (0.4.2)
+    memory_profiler (1.0.1)
     method_source (1.0.0)
     mini_mime (1.1.2)
     minitar (0.9)
@@ -445,6 +447,8 @@ GEM
     raabro (1.4.0)
     racc (1.7.1)
     rack (2.2.7)
+    rack-mini-profiler (3.1.0)
+      rack (>= 1.2.0)
     rack-protection (3.0.6)
       rack
     rack-test (2.1.0)
@@ -601,6 +605,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    stackprof (0.2.25)
     standard (1.30.1)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -709,6 +714,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   faraday-http-cache
+  flamegraph
   flipper (~> 0.28.0)
   flipper-active_record (~> 0.28.0)
   flipper-ui (~> 0.28.0)
@@ -721,6 +727,7 @@ DEPENDENCIES
   jquery-rails
   json-jwt (~> 1.15)
   lograge
+  memory_profiler
   mock_redis (~> 0.36.0)
   mysql2 (~> 0.5)
   nla-blacklight_common!
@@ -728,6 +735,7 @@ DEPENDENCIES
   oauth2 (~> 2.0)
   openurl
   puma (~> 6.0)
+  rack-mini-profiler
   rails (~> 7.0.4)
   rails-controller-testing (~> 1.0, >= 1.0.5)
   rails_performance
@@ -744,6 +752,7 @@ DEPENDENCIES
   simplecov-json (~> 0.2.3)
   solr_wrapper (>= 0.3)
   sprockets-rails
+  stackprof
   standard
   stimulus-rails
   strong_migrations (~> 1.4)

--- a/app/components/request_item_component.rb
+++ b/app/components/request_item_component.rb
@@ -20,7 +20,7 @@ class RequestItemComponent < ViewComponent::Base
   def before_render
     instance_id = @document.first("folio_instance_id_ssim")
     begin
-      @holdings = cat_services_client.get_holdings(instance_id: instance_id)
+      @holdings = CatalogueServicesClient.new.get_holdings(instance_id: instance_id)
     rescue ServiceTokenError, HoldingsRequestError, StandardError => e
       @error = "Unable to retrieve holdings for #{@document.first("title_tsim")}"
       Rails.logger.error "Unable to retrieve holdings for #{@document.id}: #{e}"
@@ -50,11 +50,5 @@ class RequestItemComponent < ViewComponent::Base
     elsif item["requestable"]
       link_to I18n.t("requesting.btn_select"), solr_document_request_new_path(solr_document_id: @document.id, holdings: holdings_id, item: item_id), class: "btn btn-primary", target: "_top"
     end
-  end
-
-  private
-
-  def cat_services_client
-    @catalogue_services_client ||= CatalogueServicesClient.new
   end
 end

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -4,7 +4,7 @@ class AccountController < ApplicationController
   before_action :authenticate_user!
 
   def requests
-    @met_request_limit = helpers.cat_services_client.request_limit_reached?(requester: current_user.folio_id)
-    @requests = helpers.cat_services_client.get_request_summary(folio_id: current_user.folio_id)
+    @met_request_limit = CatalogueServicesClient.new.request_limit_reached?(requester: current_user.folio_id)
+    @requests = CatalogueServicesClient.new.get_request_summary(folio_id: current_user.folio_id)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :store_user_location!, if: :storable_location?
+  before_action :authorize_profile
 
   # Adds a few additional behaviors into the application controller
   include Blacklight::Controller
@@ -9,12 +10,6 @@ class ApplicationController < ActionController::Base
   # Make sure to use an absolute path when rendering the partial because
   # view context is based on the executing controller.
   append_view_path "#{Rails.root}/app/components/"
-
-  # :nocov:
-  def staff_login
-    redirect_post(user_keycloakopenid_omniauth_authorize_path, options: {authenticity_token: "auto"})
-  end
-  # :nocov:
 
   private
 
@@ -43,6 +38,10 @@ class ApplicationController < ActionController::Base
   def store_user_location!
     # :user is the scope we are authenticating
     store_location_for(:user, request.fullpath)
+  end
+
+  def authorize_profile
+    Rack::MiniProfiler.authorize_request if Whitelist.instance.location(request) == :staff && ENV.fetch("ENABLE_PROFILER") { "n" } == "y"
   end
   # :nocov:
 end

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -19,7 +19,7 @@ class RequestController < ApplicationController
     holdings_id = request_params[:holdings]
     item_id = request_params[:item]
 
-    holding, item = cat_services_client.get_holding(instance_id: instance_id, holdings_id: holdings_id, item_id: item_id)
+    holding, item = CatalogueServicesClient.new.get_holding(instance_id: instance_id, holdings_id: holdings_id, item_id: item_id)
 
     @request_form = if item["itemCategory"] == "manuscript"
       "manuscripts"
@@ -50,6 +50,7 @@ class RequestController < ApplicationController
     new_request = request_params[:request].to_h
     new_request.merge!({instance_id: instance_id})
 
+    cat_services_client = CatalogueServicesClient.new
     _holding, @item = cat_services_client.get_holding(instance_id: instance_id, holdings_id: holdings_id, item_id: item_id)
     cat_services_client.create_request(requester: current_user.folio_id, request: new_request)
 
@@ -61,7 +62,7 @@ class RequestController < ApplicationController
     holdings_id = request_params[:holdings]
     item_id = request_params[:item]
 
-    _, @item = cat_services_client.get_holding(instance_id: instance_id, holdings_id: holdings_id, item_id: item_id)
+    _, @item = CatalogueServicesClient.new.get_holding(instance_id: instance_id, holdings_id: holdings_id, item_id: item_id)
 
     if @item["pickupLocation"]["code"].start_with? "SCRR"
       @show_scrr = true
@@ -69,10 +70,6 @@ class RequestController < ApplicationController
   end
 
   private
-
-  def cat_services_client
-    helpers.cat_services_client
-  end
 
   def set_document
     _deprecated_response, @document = search_service.fetch(request_params[:solr_document_id])
@@ -83,6 +80,6 @@ class RequestController < ApplicationController
   end
 
   def check_request_limit
-    @met_request_limit = cat_services_client.request_limit_reached?(requester: current_user.folio_id)
+    @met_request_limit = CatalogueServicesClient.new.request_limit_reached?(requester: current_user.folio_id)
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -47,11 +47,7 @@ class SearchController < ApplicationController
       @eds_per_page
     end
 
-    @results = {}
-
-    Benchmark.bm do |x|
-      x.report(@engine) { @results = BentoSearch.get_engine(@engine.to_sym).search(@query, per_page: @per_page, search_field: @search_field) }
-    end
+    @results = BentoSearch.get_engine(@engine.to_sym).search(@query, per_page: @per_page, search_field: @search_field)
 
     @total_results = @results.total_items.nil? ? 0 : @results.total_items
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -70,14 +70,6 @@ module ApplicationHelper
     end
   end
 
-  def cat_services_client
-    @catalogue_services_client ||= CatalogueServicesClient.new
-  end
-
-  def thumbnail_service
-    @thumbnail_service ||= ThumbnailService.new
-  end
-
   private
 
   def makelink_eresource(href)

--- a/app/helpers/thumbnail_helper.rb
+++ b/app/helpers/thumbnail_helper.rb
@@ -1,17 +1,19 @@
 # frozen_string_literal: true
 
 module ThumbnailHelper
+  NLA_OBJ_ID_FIELD = "nlaobjid_ss"
+
   def render_thumbnail(document, options = {})
     return if document.first("id").blank?
 
     service_options = {
-      nlaObjId: document.first("nlaobjid_ss"),
+      nlaObjId: document.first(NLA_OBJ_ID_FIELD),
       isbnList: document.isbn_list.join(","),
       lccnList: document.lccn.join(","),
       width: thumbnail_image_width(document)
     }
 
-    thumb_url = thumbnail_service.get_url(service_options)
+    thumb_url = ThumbnailService.new.get_url(service_options)
     if thumb_url.present?
       image_tag thumb_url, options
     end

--- a/app/services/catalogue_services_client.rb
+++ b/app/services/catalogue_services_client.rb
@@ -19,10 +19,6 @@ class CatalogueServicesClient
   }
   # rubocop:enable Lint/SymbolConversion
 
-  def initialize
-    @oauth_client ||= init_client
-  end
-
   def get_request_summary(folio_id:)
     conn = Faraday.new(url: ENV["CATALOGUE_SERVICES_API_BASE_URL"]) do |f|
       f.response :json
@@ -109,15 +105,5 @@ class CatalogueServicesClient
       # user will likely be unable to request items also (i.e. their account is broken).
       raise ItemRequestError.new(message)
     end
-  end
-
-  private
-
-  def init_client
-    site = "#{ENV["KEYCLOAK_URL"]}/auth/realms/#{ENV["CATALOGUE_SERVICES_REALM"]}/.well-known/openid-configuration"
-    OAuth2::Client.new(ENV["CATALOGUE_SERVICES_CLIENT"], ENV["CATALOGUE_SERVICES_SECRET"],
-      site: site,
-      authorize_url: "/auth/realms/#{ENV["CATALOGUE_SERVICES_REALM"]}/protocol/openid-connect/auth",
-      token_url: "/auth/realms/#{ENV["CATALOGUE_SERVICES_REALM"]}/protocol/openid-connect/token")
   end
 end

--- a/app/views/account/requests.html.erb
+++ b/app/views/account/requests.html.erb
@@ -1,6 +1,6 @@
 <h2><%= t("account.requests.heading") %></h2>
 
-<%= render RequestLimitMessageComponent.new(current_user, cat_services_client) do |component| %>
+<%= render RequestLimitMessageComponent.new(current_user, CatalogueServicesClient.new) do |component| %>
   <% component.with_limit_reached.with_content(@met_request_limit) %>
   <% component.with_remaining_requests.with_content(@requests["numRequestsRemaining"]) %>
 <% end %>

--- a/app/views/request/new.html.erb
+++ b/app/views/request/new.html.erb
@@ -1,6 +1,6 @@
 <h1 class="h3"><%= @document.first("title_tsim") %></h1>
 
-<%= render RequestLimitMessageComponent.new(current_user, cat_services_client) do |component| %>
+<%= render RequestLimitMessageComponent.new(current_user, CatalogueServicesClient.new) do |component| %>
   <% component.with_limit_reached.with_content(@met_request_limit) %>
 <% end %>
 

--- a/app/views/request/success.html.erb
+++ b/app/views/request/success.html.erb
@@ -1,4 +1,4 @@
-<%= render RequestLimitMessageComponent.new(current_user, cat_services_client) do |component| %>
+<%= render RequestLimitMessageComponent.new(current_user, CatalogueServicesClient.new) do |component| %>
   <% component.with_limit_reached.with_content(@met_request_limit) %>
 <% end %>
 

--- a/config/initializers/rack-mini-profiler.rb
+++ b/config/initializers/rack-mini-profiler.rb
@@ -1,0 +1,3 @@
+require "rack-mini-profiler"
+
+Rack::MiniProfiler.config.storage = Rack::MiniProfiler::MemoryStore


### PR DESCRIPTION
Remove the authentication code from the catalogue services client code and some other bits that are no longer relevant.

Have added rack-mini profiler and the ability to turn it on in prod if needed.