### PR TITLE
feat: restyle title links and silence deprecations

### DIFF
--- a/app/assets/stylesheets/nla/_record.scss
+++ b/app/assets/stylesheets/nla/_record.scss
@@ -1,8 +1,6 @@
 @charset "UTF-8";
 @import "variables";
 
-
-
 .document-thumbnail {
   &.col-12 a {
     position: relative;
@@ -40,5 +38,19 @@
 .document {
   .dl-invert dt {
     color: color("gray-medium-light");
+  }
+}
+
+.document-title-heading {
+  .document-counter {
+    display: none;
+  }
+
+  a {
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 }

--- a/app/assets/stylesheets/nla/components/_bento-search.scss
+++ b/app/assets/stylesheets/nla/components/_bento-search.scss
@@ -50,7 +50,14 @@
   }
   
   .bento-item-title {
-    font-size: 1.25rem
+    font-size: 1.25rem;
+    a {
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
   }
 }
 

--- a/app/views/bento_search/_item_title.html.erb
+++ b/app/views/bento_search/_item_title.html.erb
@@ -18,12 +18,6 @@
   #
   # %>
   <h3 class="bento-item-title col-12">
-    <% if local_assigns[:index] %>
-      <% id_attr = item.html_id(local_assigns[:id_prefix], index) %>
-      <%= content_tag("span", :class => "bento_index", :id => (id_attr if id_attr)) do %>
-        <%= index %>.
-      <% end %>
-    <% end %>
     <%= link_to_unless(item.link.blank?, item.complete_title.truncate(175, separator: " "), item.link) %>
 
     <% if item.display_language.present? %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,12 @@ if %w[development test].include? ENV["RAILS_ENV"]
   Dotenv::Railtie.load
 end
 
+if %w[staging production].include? ENV["RAILS_ENV"]
+  # Silence deprecation warnings in staging/production
+  require "deprecation"
+  Deprecation.default_deprecation_behavior = :silence
+end
+
 module NlaBlacklight
   VERSION = "2.3.2"
 


### PR DESCRIPTION
Removes underlines and numbering from title links.

Also added some code to silence the deprecation warnings in staging/prod so they don't clutter up the logs.