### PR TITLE
fix: reduce memory usage

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,7 @@ AllCops:
     - db/**/*
     - bin/**/*
     - tmp/**/*
+    - config/puma.rb
 
 Rails:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -106,9 +106,6 @@ gem "flipper-ui", "~> 0.28.0"
 # Fixes CVE-2023-28755
 gem "uri", "~> 0.12.1"
 
-# performance monitoring
-gem "rails_performance"
-
 # Before a release, point these gem at a tag, instead of the `main` branch.
 gem "nla-blacklight_common", git: "https://github.com/nla/nla-blacklight_common", branch: "main"
 gem "bento_search", git: "https://github.com/nla/bento_search.git", tag: "0.0.1"

--- a/Gemfile
+++ b/Gemfile
@@ -115,8 +115,6 @@ gem "bento_search", git: "https://github.com/nla/bento_search.git", tag: "0.0.1"
 # gem "nla-blacklight_common", path: "../nla-blacklight_common"
 # gem "bento_search", path: "../bento_search"
 
-gem "puma_worker_killer", "~> 0.3.0"
-
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -110,12 +110,12 @@ gem "uri", "~> 0.12.1"
 gem "rails_performance"
 
 # Before a release, point these gem at a tag, instead of the `main` branch.
-gem "nla-blacklight_common", git: "https://github.com/nla/nla-blacklight_common", branch: "main"
+# gem "nla-blacklight_common", git: "https://github.com/nla/nla-blacklight_common", branch: "main"
 gem "bento_search", git: "https://github.com/nla/bento_search.git", tag: "0.0.1"
 
 # For local development, comment out above ⤴️ and uncomment below ⤵️. Assumes this directory and
 # the gems below are in the same directory. Adjust if needed to match your local dev environment.
-# gem "nla-blacklight_common", path: "../nla-blacklight_common"
+gem "nla-blacklight_common", path: "../nla-blacklight_common"
 # gem "bento_search", path: "../bento_search"
 
 gem "puma_worker_killer", "~> 0.3.0"

--- a/Gemfile
+++ b/Gemfile
@@ -110,12 +110,12 @@ gem "uri", "~> 0.12.1"
 gem "rails_performance"
 
 # Before a release, point these gem at a tag, instead of the `main` branch.
-# gem "nla-blacklight_common", git: "https://github.com/nla/nla-blacklight_common", branch: "main"
+gem "nla-blacklight_common", git: "https://github.com/nla/nla-blacklight_common", branch: "main"
 gem "bento_search", git: "https://github.com/nla/bento_search.git", tag: "0.0.1"
 
 # For local development, comment out above ⤴️ and uncomment below ⤵️. Assumes this directory and
 # the gems below are in the same directory. Adjust if needed to match your local dev environment.
-gem "nla-blacklight_common", path: "../nla-blacklight_common"
+# gem "nla-blacklight_common", path: "../nla-blacklight_common"
 # gem "bento_search", path: "../bento_search"
 
 gem "puma_worker_killer", "~> 0.3.0"

--- a/Gemfile
+++ b/Gemfile
@@ -118,15 +118,7 @@ gem "bento_search", git: "https://github.com/nla/bento_search.git", tag: "0.0.1"
 # gem "nla-blacklight_common", path: "../nla-blacklight_common"
 # gem "bento_search", path: "../bento_search"
 
-# Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
-gem "rack-mini-profiler"
-# append ?pp=flamegraph to URL for flamegraphs
-gem "flamegraph"
-gem "stackprof"
-# append ?pp=profile-memory to URL
-# ?pp=profile-gc to report on GC statistics
-# ?pp=analyze-memory to report on Object statistics
-gem "memory_profiler"
+gem "puma_worker_killer", "~> 0.3.0"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
@@ -153,6 +145,16 @@ group :development do
 
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
+
+  # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
+  gem "rack-mini-profiler"
+  # append ?pp=flamegraph to URL for flamegraphs
+  gem "flamegraph"
+  gem "stackprof"
+  # append ?pp=profile-memory to URL
+  # ?pp=profile-gc to report on GC statistics
+  # ?pp=analyze-memory to report on Object statistics
+  gem "memory_profiler"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 
 GIT
   remote: https://github.com/nla/nla-blacklight_common
-  revision: 2c4d01211119c5fdb6f092a1fbf5cf82e5993c98
+  revision: 7b54a0d07f5ec3e6096be7c12ffe251d8794e3c4
   branch: main
   specs:
     nla-blacklight_common (0.1.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,8 +15,10 @@ GIT
       rails-controller-testing
       summon
 
-PATH
-  remote: ../nla-blacklight_common
+GIT
+  remote: https://github.com/nla/nla-blacklight_common
+  revision: 2c4d01211119c5fdb6f092a1fbf5cf82e5993c98
+  branch: main
   specs:
     nla-blacklight_common (0.1.4)
       activerecord-session_store (~> 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 
 GIT
   remote: https://github.com/nla/nla-blacklight_common
-  revision: 30d3caa53175e1247a5b0b290397949d6b5e87de
+  revision: 8bed29750b31f667a4981a7e0752a13fe9e3638d
   branch: main
   specs:
     nla-blacklight_common (0.1.4)
@@ -297,6 +297,8 @@ GEM
     fugit (1.8.1)
       et-orbi (~> 1, >= 1.2.7)
       raabro (~> 1.4)
+    get_process_mem (0.2.7)
+      ffi (~> 1.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
     hashdiff (1.0.1)
@@ -379,7 +381,7 @@ GEM
     matrix (0.4.2)
     memory_profiler (1.0.1)
     method_source (1.0.0)
-    mini_mime (1.1.2)
+    mini_mime (1.1.5)
     minitar (0.9)
     minitest (5.19.0)
     mock_redis (0.36.0)
@@ -444,13 +446,16 @@ GEM
     public_suffix (4.0.7)
     puma (6.3.0)
       nio4r (~> 2.0)
+    puma_worker_killer (0.3.1)
+      get_process_mem (~> 0.2)
+      puma (>= 2.7)
     raabro (1.4.0)
     racc (1.7.1)
-    rack (2.2.7)
+    rack (2.2.8)
     rack-mini-profiler (3.1.0)
       rack (>= 1.2.0)
-    rack-protection (3.0.6)
-      rack
+    rack-protection (3.1.0)
+      rack (~> 2.2, >= 2.2.4)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.6)
@@ -471,7 +476,7 @@ GEM
       actionpack (>= 5.0.1.rc1)
       actionview (>= 5.0.1.rc1)
       activesupport (>= 5.0.1.rc1)
-    rails-dom-testing (2.1.1)
+    rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
@@ -677,7 +682,7 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yell (2.2.2)
-    zeitwerk (2.6.9)
+    zeitwerk (2.6.11)
     zk (1.10.0)
       zookeeper (~> 1.5.0)
     zookeeper (1.5.5)
@@ -735,6 +740,7 @@ DEPENDENCIES
   oauth2 (~> 2.0)
   openurl
   puma (~> 6.0)
+  puma_worker_killer (~> 0.3.0)
   rack-mini-profiler
   rails (~> 7.0.4)
   rails-controller-testing (~> 1.0, >= 1.0.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,10 +15,8 @@ GIT
       rails-controller-testing
       summon
 
-GIT
-  remote: https://github.com/nla/nla-blacklight_common
-  revision: 8bed29750b31f667a4981a7e0752a13fe9e3638d
-  branch: main
+PATH
+  remote: ../nla-blacklight_common
   specs:
     nla-blacklight_common (0.1.4)
       activerecord-session_store (~> 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,7 +160,6 @@ GEM
       popper_js (>= 1.16.1, < 2)
       sassc-rails (>= 2.0.0)
     brakeman (6.0.1)
-    browser (5.3.1)
     builder (3.2.4)
     bundler-audit (0.9.1)
       bundler (>= 1.2.0, < 3)
@@ -483,11 +482,6 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
-    rails_performance (1.2.0)
-      browser
-      rails
-      redis
-      redis-namespace
     railties (7.0.6)
       actionpack (= 7.0.6)
       activesupport (= 7.0.6)
@@ -501,8 +495,6 @@ GEM
       redis-client (>= 0.9.0)
     redis-client (0.14.1)
       connection_pool
-    redis-namespace (1.11.0)
-      redis (>= 4)
     regexp_parser (2.8.1)
     reline (0.3.6)
       io-console (~> 0.5)
@@ -744,7 +736,6 @@ DEPENDENCIES
   rack-mini-profiler
   rails (~> 7.0.4)
   rails-controller-testing (~> 1.0, >= 1.0.5)
-  rails_performance
   redis (~> 5.0)
   repost (~> 0.4.1)
   rsolr (>= 1.0, < 3)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -60,11 +60,9 @@ module ApplicationHelper
     file_path = "#{Rails.root}/app/assets/images/#{name}.svg"
 
     if File.exist?(file_path)
-      Rails.cache.fetch("svg-#{name}", expires_in: 1.year) do
-        # rubocop:disable Rails/OutputSafety
-        File.read(file_path).html_safe
-        # rubocop:enable Rails/OutputSafety
-      end
+      # rubocop:disable Rails/OutputSafety
+      File.read(file_path).html_safe
+      # rubocop:enable Rails/OutputSafety
     else
       "(not found)"
     end

--- a/app/helpers/thumbnail_helper.rb
+++ b/app/helpers/thumbnail_helper.rb
@@ -18,6 +18,7 @@ module ThumbnailHelper
       image_tag thumb_url, options
     else
       Rails.logger.warn "Failed to retrieve thumbnail for #{document.first("id")}"
+      nil
     end
   end
 

--- a/app/helpers/thumbnail_helper.rb
+++ b/app/helpers/thumbnail_helper.rb
@@ -16,6 +16,8 @@ module ThumbnailHelper
     thumb_url = ThumbnailService.new.get_url(service_options)
     if thumb_url.present?
       image_tag thumb_url, options
+    else
+      Rails.logger.warn "Failed to retrieve thumbnail for #{document.first("id")}"
     end
   end
 

--- a/app/models/request_detail.rb
+++ b/app/models/request_detail.rb
@@ -34,14 +34,12 @@ class RequestDetail
   def fetch_record_id
     if @details.instanceId.present?
       search_service = Blacklight.repository_class.new(blacklight_config)
-      response = Rails.cache.fetch("#{@details.instanceId}_record", expires_in: 15.minutes) do
-        search_service.search(
-          q: "folio_instance_id_ssim:\"#{@details.instanceId}\"",
-          fl: "id",
-          sort: "score desc",
-          rows: 1
-        )
-      end
+      response = search_service.search(
+        q: "folio_instance_id_ssim:\"#{@details.instanceId}\"",
+        fl: "id",
+        sort: "score desc",
+        rows: 1
+      )
       if response.present? && response["response"].present?
         doc = response["response"]["docs"].first
         doc.present? ? doc["id"] : nil

--- a/app/services/thumbnail_service.rb
+++ b/app/services/thumbnail_service.rb
@@ -7,14 +7,12 @@ class ThumbnailService
     end
 
     url = "/thumbnail-service/thumbnail/url?#{options.to_query}"
-    Rails.cache.fetch("thumb_url_#{url}", expires: 6.hours) do
-      res = conn.get(url)
-      if res.status == 200
-        res.body["url"]
-      else
-        Rails.logger.error "Failed to retrieve thumbnail for #{options.to_json}"
-        nil
-      end
+    res = conn.get(url)
+    if res.status == 200
+      res.body["url"]
+    else
+      Rails.logger.error "Failed to retrieve thumbnail for #{options.to_json}"
+      nil
     end
   end
 
@@ -24,15 +22,13 @@ class ThumbnailService
     conn = Faraday.new(url: ENV["THUMBNAIL_SERVICE_API_BASE_URL"])
 
     url = "/thumbnail-service/thumbnail/retrieve?#{options.to_query}"
-    Rails.cache.fetch("thumb_raw_#{url}", expires: 1.year) do
-      res = conn.get(url)
-      if res.status == 200
-        content_type = res.headers["content-type"]
-        "data:#{content_type};base64,#{Base64.encode64(res.body).gsub("\n", "")}"
-      else
-        Rails.logger.error "Failed to retrieve thumbnail for #{options.to_json}"
-        nil
-      end
+    res = conn.get(url)
+    if res.status == 200
+      content_type = res.headers["content-type"]
+      "data:#{content_type};base64,#{Base64.encode64(res.body).gsub("\n", "")}"
+    else
+      Rails.logger.error "Failed to retrieve thumbnail for #{options.to_json}"
+      nil
     end
   end
   # :nocov:

--- a/app/services/thumbnail_service.rb
+++ b/app/services/thumbnail_service.rb
@@ -10,8 +10,6 @@ class ThumbnailService
     res = conn.get(url)
     if res.status == 200
       res.body["url"]
-    else
-      nil
     end
   end
 
@@ -25,8 +23,6 @@ class ThumbnailService
     if res.status == 200
       content_type = res.headers["content-type"]
       "data:#{content_type};base64,#{Base64.encode64(res.body).gsub("\n", "")}"
-    else
-      nil
     end
   end
   # :nocov:

--- a/app/services/thumbnail_service.rb
+++ b/app/services/thumbnail_service.rb
@@ -11,7 +11,6 @@ class ThumbnailService
     if res.status == 200
       res.body["url"]
     else
-      Rails.logger.error "Failed to retrieve thumbnail for #{options.to_json}"
       nil
     end
   end
@@ -27,7 +26,6 @@ class ThumbnailService
       content_type = res.headers["content-type"]
       "data:#{content_type};base64,#{Base64.encode64(res.body).gsub("\n", "")}"
     else
-      Rails.logger.error "Failed to retrieve thumbnail for #{options.to_json}"
       nil
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,7 @@ if %w[development test].include? ENV["RAILS_ENV"]
   Dotenv::Railtie.load
 end
 
-if %w[staging production].include? ENV["RAILS_ENV"]
+if %w[development staging production].include? ENV["RAILS_ENV"]
   # Silence deprecation warnings in staging/production
   require "deprecation"
   Deprecation.default_deprecation_behavior = :silence

--- a/config/database.yml
+++ b/config/database.yml
@@ -13,6 +13,9 @@ default: &default
   adapter: mysql2
   encoding: utf8mb4
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  connect_timeout: 60
+  read_timeout: 60
+  write_timeout: 60
   username: root
   password:
   host: 127.0.0.1
@@ -23,6 +26,9 @@ patrons: &patrons
   adapter: mysql2
   encoding: utf8mb4
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  connect_timeout: 60
+  read_timeout: 60
+  write_timeout: 60
   username: root
   password:
   host: 127.0.0.1

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,8 +31,8 @@ Rails.application.configure do
       driver: :hiredis,
       url: ENV["REDIS_URL"],
       timeout: 30,
-      reconnect_attempts: 3,
-      expires_in: 1.day,
+      reconnect_attempts: 1,
+      expires_in: 1.hour,
       namespace: "blacklight"
     }
     config.public_file_server.headers = {

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).
-  config.log_level = :info
+  config.log_level = ENV.fetch("RAILS_LOG_LEVEL") { "info" }
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
@@ -60,8 +60,8 @@ Rails.application.configure do
     driver: :hiredis,
     url: ENV["REDIS_URL"],
     timeout: 30,
-    reconnect_attempts: 3,
-    expires_in: 1.day,
+    reconnect_attempts: 1,
+    expires_in: 1.hour,
     namespace: "blacklight"
   }
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,8 +33,8 @@ Rails.application.configure do
     driver: :hiredis,
     url: ENV["REDIS_URL"],
     timeout: 30,
-    reconnect_attempts: 3,
-    expires_in: 1.day,
+    reconnect_attempts: 1,
+    expires_in: 1.hour,
     namespace: "blacklight"
   }
 

--- a/config/initializers/rack-mini-profiler.rb
+++ b/config/initializers/rack-mini-profiler.rb
@@ -1,6 +1,0 @@
-require "rack-mini-profiler"
-
-if Rails.env.production?
-  Rack::MiniProfiler.config.storage_options = {url: ENV["REDIS_URL"]}
-  Rack::MiniProfiler.config.storage = Rack::MiniProfiler::RedisStore
-end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -47,7 +47,7 @@ before_fork do
 
   PumaWorkerKiller.config do |config|
     config.ram = 10240 # mb
-    config.frequency = 2 # seconds
+    config.frequency = 5 # seconds
     config.percent_usage = 0.9
     config.rolling_restart_frequency = 2 * 3600 # seconds
     config.reaper_status_logs = true

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -30,7 +30,7 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
@@ -41,3 +41,19 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
+
+before_fork do
+  require "puma_worker_killer"
+
+  PumaWorkerKiller.config do |config|
+    config.ram = 10240 # mb
+    config.frequency = 5 # seconds
+    config.percent_usage = 0.9
+    config.rolling_restart_frequency = 2 * 3600 # seconds
+    config.reaper_status_logs = true
+
+    config.pre_term = ->(worker) { puts "Worker #{worker.inspect} being killed" }
+    config.rolling_pre_term = ->(worker) { puts "Worker #{worker.inspect} being killed by rolling restart" }
+  end
+  PumaWorkerKiller.start
+end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -47,7 +47,7 @@ before_fork do
 
   PumaWorkerKiller.config do |config|
     config.ram = 10240 # mb
-    config.frequency = 30 # seconds
+    config.frequency = 2 # seconds
     config.percent_usage = 0.9
     config.rolling_restart_frequency = 2 * 3600 # seconds
     config.reaper_status_logs = true

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -47,7 +47,7 @@ before_fork do
 
   PumaWorkerKiller.config do |config|
     config.ram = 10240 # mb
-    config.frequency = 5 # seconds
+    config.frequency = 30 # seconds
     config.percent_usage = 0.9
     config.rolling_restart_frequency = 2 * 3600 # seconds
     config.reaper_status_logs = true

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -30,7 +30,7 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-workers ENV.fetch("WEB_CONCURRENCY") { 3 }
+# workers ENV.fetch("WEB_CONCURRENCY") { 3 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
@@ -41,19 +41,3 @@ workers ENV.fetch("WEB_CONCURRENCY") { 3 }
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
-
-before_fork do
-  require "puma_worker_killer"
-
-  PumaWorkerKiller.config do |config|
-    config.ram = 10240 # mb
-    config.frequency = 5 # seconds
-    config.percent_usage = 0.9
-    config.rolling_restart_frequency = 2 * 3600 # seconds
-    config.reaper_status_logs = true
-
-    config.pre_term = ->(worker) { puts "Worker #{worker.inspect} being killed" }
-    config.rolling_pre_term = ->(worker) { puts "Worker #{worker.inspect} being killed by rolling restart" }
-  end
-  PumaWorkerKiller.start
-end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -30,7 +30,7 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 3 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,6 @@ Rails.application.routes.draw do
   mount Blacklight::Engine => "/"
   mount BlacklightAdvancedSearch::Engine => "/"
   mount Flipper::UI.app(Flipper) => "/feats", :constraints => StaffOnlyConstraint.new
-  mount RailsPerformance::Engine => "/monitor", :constraints => StaffOnlyConstraint.new
 
   concern :exportable, Blacklight::Routes::Exportable.new
   concern :searchable, Blacklight::Routes::Searchable.new


### PR DESCRIPTION
- Add `puma_worker_killer` for rolling phased restarts of Puma.
- Remove cache writes to Redis
- Silence deprecation warnings in devel also
- Make prod database timeouts the default in all environments
- Remove `rails_performance` to reduce Redis usage