### PR TITLE
BLAC-464: change green text in modal to grey

### DIFF
--- a/app/assets/stylesheets/nla/_facets.scss
+++ b/app/assets/stylesheets/nla/_facets.scss
@@ -56,7 +56,7 @@
     }
     
     .selected {
-      color: #46474A !important;
+      color: color("gray-medium") !important;
     }
     
     .remove {
@@ -93,6 +93,12 @@
 
 // Blacklight Range Limit slider in modal
 .modal-body {
+  .facet-values {
+    .selected {
+      color: color("gray-medium") !important;
+    }
+  }
+  
   .slider_js {
     .slider-handle {
       background-image: none;


### PR DESCRIPTION
Sorry, Just one very small fix for some bright green text showing up in the year chart modal. I'm also seeing an "=" sign just in the Catalogue version. Wasn't appearing in Finding aids, but I couldn't work out where it was coming from.