### PR TITLE
Chore/clear cache with large number of keys

### DIFF
--- a/nla-deploy.sh
+++ b/nla-deploy.sh
@@ -53,7 +53,7 @@ mkdir -p "$BLACKLIGHT_TMP_PATH"/pids
 # Using file cache, so tmp:clear will also clear the cache
 RAILS_ENV=$RAILS_ENV bundle exec rails log:clear tmp:clear
 # Clear the Redis cache
-redis-cli -n 0 KEYS "blacklight:*" | xargs redis-cli DEL
+redis-cli -n 0 KEYS "blacklight:*" | xargs redis-cli -n 0 DEL
 
 # Remove a potentially pre-existing server.pid for Rails.
 rm -f "$PIDFILE"

--- a/nla-deploy.sh
+++ b/nla-deploy.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
 
-redis_cache_clear() {
-  keys=$(redis-cli -n 0 KEYS "blacklight:*")
-
-  if [[ $keys ]]; then
-    redis-cli -n 0 DEL $keys
-  fi
-}
-
 ORIGDIR=$(pwd)
 export ORIGDIR
 source ~/.bashrc
@@ -61,7 +53,7 @@ mkdir -p "$BLACKLIGHT_TMP_PATH"/pids
 # Using file cache, so tmp:clear will also clear the cache
 RAILS_ENV=$RAILS_ENV bundle exec rails log:clear tmp:clear
 # Clear the Redis cache
-redis_cache_clear
+redis-cli -n 0 KEYS "blacklight:*" | xargs redis-cli DEL
 
 # Remove a potentially pre-existing server.pid for Rails.
 rm -f "$PIDFILE"


### PR DESCRIPTION
When deploying in prod we got /bin/redis-cli: Argument list too long, there were over 1200 keys in the cache so changed to use xargs