### PR TITLE
BLAC-528 Stop record view crashing with bad URL values

### DIFF
--- a/app/helpers/single_search_helper.rb
+++ b/app/helpers/single_search_helper.rb
@@ -58,7 +58,12 @@ module SingleSearchHelper
   end
 
   def is_catalogued?(url)
-    uri = Addressable::URI.parse(url) || nil
+    begin
+      uri = Addressable::URI.parse(url) || nil
+    rescue Addressable::URI::InvalidURIError
+      uri = nil
+    end
+
     if uri.nil?
       false
     else

--- a/app/models/search_link.rb
+++ b/app/models/search_link.rb
@@ -67,7 +67,12 @@ class SearchLink
 
       # Uses Addressable::URI because the standard URI library cannot
       # handle query strings in the URL when parsing for the file extension
-      uri = Addressable::URI.parse(url) || nil
+      begin
+        uri = Addressable::URI.parse(url) || nil
+      rescue Addressable::URI::InvalidURIError
+        uri = nil
+      end
+
       unless uri.nil?
         file_extension = uri.extname
         unless file_extension.nil?
@@ -90,8 +95,11 @@ class SearchLink
   def extract_domain(url)
     result = ""
     unless url.empty?
-      host = Addressable::URI.parse(url).host || ""
-
+      begin
+        host = Addressable::URI.parse(url).host || ""
+      rescue Addressable::URI::InvalidURIError
+        host = ""
+      end
       if host.present?
         segments = host.split(".").reverse
 

--- a/spec/helpers/single_search_helper_spec.rb
+++ b/spec/helpers/single_search_helper_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe SingleSearchHelper do
     it "returns false if the url is nil" do
       expect(helper.is_catalogued?(nil)).to be false
     end
+
+    it "returns false if the url is invalid" do
+      expect(helper.is_catalogued?("not a url")).to be false
+    end
   end
 
   describe "#ss_uri_encode" do

--- a/spec/helpers/single_search_helper_spec.rb
+++ b/spec/helpers/single_search_helper_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe SingleSearchHelper do
     end
 
     it "returns false if the url is invalid" do
-      expect(helper.is_catalogued?("not a url")).to be false
+      expect(helper.is_catalogued?("Full text available from Masterfile Premier: 01/01/1990 to present")).to be false
     end
   end
 


### PR DESCRIPTION
There are some 856 u fields which are just text, like a note or the link text. When the URL is parsed it fails so this just catches the exception and essentially ignores the value. The actual problem was in the google url builder but I have added the error handling wherever the URL might be parsed by Addressable.

It was also a bit weird, a url value of"this is not a url" doesn't throw an exception, but "Full text available from Masterfile Premier: 01/01/1990 to present" did, so probably only a limited number will fail anyway, I guess it's the colon.