### PR TITLE
fix: turn off force_ssl and add "localhost" to hosts in staging/prod

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  # config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).
@@ -97,5 +97,6 @@ Rails.application.configure do
 
   # allow requests to
   config.hosts.clear
+  config.hosts << "localhost"
   config.hosts << ".nla.gov.au"
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -8,5 +8,6 @@ Rails.application.configure do
 
   # allow requests to
   config.hosts.clear
+  config.hosts << "localhost"
   config.hosts << ".nla.gov.au"
 end


### PR DESCRIPTION
Tested with current code in nla-blacklight_common that forces the cookie to be secure in production: https://github.com/nla/nla-blacklight_common/blob/669fd6d2ea38b661f68b03cfb240c018374e5e80/config/initializers/session_store.rb#L1

Also added "localhost" to the allowed hosts in staging and prod configs, in case something needs to access it from localhost. Most likely not.