### PR TITLE
revert: revert display of year, enumeration and chronology

### DIFF
--- a/app/components/request_table_row_component.html.erb
+++ b/app/components/request_table_row_component.html.erb
@@ -2,15 +2,6 @@
   <td><%= link_to_record %></td>
   <td><%= @request_details.pickupServicePoint %></td>
   <td>
-    <%- if @request_details.yearCaption %>
-      <p><%= @request_details.yearCaption %></p>
-    <%- end %>
-    <%- if @request_details.enumeration %>
-      <p><%= @request_details.enumeration %></p>
-    <%- end %>
-    <%- if @request_details.chronology %>
-      <p><%= @request_details.chronology %></p>
-    <%- end %>
     <%- if @request_details.patronComments %>
       <p><%= @request_details.patronComments %></p>
     <%- end %>

--- a/spec/components/request_table_row_component_spec.rb
+++ b/spec/components/request_table_row_component_spec.rb
@@ -67,24 +67,6 @@ RSpec.describe RequestTableRowComponent, type: :component do
     expect(page).to have_css("small.text-muted", text: "06:36:33pm")
   end
 
-  it "renders the year in the notes column" do
-    render_inline(described_class.new(request_data))
-
-    expect(page).to have_css("p", text: "1909")
-  end
-
-  it "renders the enumeration in the notes column" do
-    render_inline(described_class.new(request_data))
-
-    expect(page).to have_css("p", text: "pbk")
-  end
-
-  it "renders the chronology in the notes column" do
-    render_inline(described_class.new(request_data))
-
-    expect(page).to have_css("p", text: "June, July")
-  end
-
   def request_data
     data = IO.read("spec/files/account/single_request.json")
     {request: JSON.parse(data)}


### PR DESCRIPTION
Reverts changes for BLAC-523 to add requests info to request summary notes.