### PR TITLE
feat: eResources stats

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -420,11 +420,14 @@ class CatalogController < ApplicationController
 
     if @eresource.present?
       if helpers.user_type == :local || helpers.user_type == :staff
+        CatalogueServicesClient.new.post_stats EresourcesStats.new(@eresource, helpers.user_type)
         # let them straight through
         return redirect_to url, allow_other_host: true
       elsif @eresource[:entry]["remoteaccess"] == "yes"
         # already logged in
         if current_user.present?
+          CatalogueServicesClient.new.post_stats EresourcesStats.new(@eresource, helpers.user_type)
+
           return redirect_to @eresource[:url], allow_other_host: true if @eresource[:type] == "remoteurl"
 
           # sorry for this.  EZProxy really needs a URL rewrite function.

--- a/app/models/eresources_stats.rb
+++ b/app/models/eresources_stats.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal
+
+class EresourcesStats
+  attr_reader :payload
+
+  def initialize(resource, user_type)
+    @payload = JSON.generate(
+      resource: {entry: {remoteaccess: resource[:entry]["remoteaccess"], title: resource[:entry]["title"].strip}},
+      timestamp: Time.now.to_i,
+      user_type: user_type.to_s
+    )
+  end
+end

--- a/app/services/catalogue_services_client.rb
+++ b/app/services/catalogue_services_client.rb
@@ -116,4 +116,23 @@ class CatalogueServicesClient
     Rails.logger.error "request_limit_reached? - Failed to connect catalogue-service: #{e.message}"
     raise ItemRequestError.new("Failed to check request limit for requester (#{requester})")
   end
+
+  def post_stats(stats)
+    conn = Faraday.new(url: ENV["CATALOGUE_SERVICES_API_BASE_URL"]) do |f|
+      f.response :json
+    end
+
+    res = conn.post("/catalogue-services/log/message", stats.to_json, "Content-Type" => "application/json") do |req|
+      req.headers["Content-Type"] = "application/json"
+      req.body = stats.payload
+    end
+    if res.status != 200
+      message = "Failed to post stats to eResources stats service: #{stats.payload}"
+      Rails.logger.error message
+      nil
+    end
+  rescue
+    Rails.logger.error "Failed to connect to eResources stats service: #{stats.payload}"
+    nil
+  end
 end

--- a/app/services/eresources_config_service.rb
+++ b/app/services/eresources_config_service.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "faraday"
+
+class EresourcesConfigService
+  def fetch_config
+    res = Faraday.get(ENV["ERESOURCES_CONFIG_URL"], nil, {content_type: "application/json", accept: "application/json"})
+    if res.status == 200
+      if res.body.present?
+        JSON.parse(res.body)
+      end
+    else
+      Rails.logger.error "Failed to retrieve eResources config"
+      nil
+    end
+  rescue => e
+    Rails.logger.error "Failed to retrieve or parse eResources config: #{e.message}"
+    nil
+  end
+end

--- a/config/initializers/mini_profiler.rb
+++ b/config/initializers/mini_profiler.rb
@@ -1,0 +1,4 @@
+if ENV.fetch("MINIPROFILER_REDIS", "n") == "y"
+  Rack::MiniProfiler.config.storage_options = {url: ENV["REDIS_SERVER_URL"]}
+  Rack::MiniProfiler.config.storage = Rack::MiniProfiler::RedisStore
+end

--- a/spec/requests/offsite_redirect_spec.rb
+++ b/spec/requests/offsite_redirect_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe "Offsite redirect", :request do
   include Devise::Test::IntegrationHelpers
   include ActiveSupport::Testing::TimeHelpers
 
+  let(:catalogue_service_mock) { instance_double(CatalogueServicesClient, post_stats: {}) }
+
   context "when given a 'url' param that does not start with http or https" do
     it "will raise a RuntimeError" do
       expect { get "/catalog/0000/offsite?url=htp://example.com" }.to raise_error(RuntimeError)
@@ -31,7 +33,16 @@ RSpec.describe "Offsite redirect", :request do
 
         it "redirects to the 'url'" do
           get "/catalog/0000/offsite?url=http://opac.newsbank.com/select/shaw/35846"
+
           expect(request).to redirect_to("http://opac.newsbank.com/select/shaw/35846")
+        end
+
+        it "posts stats" do
+          allow(CatalogueServicesClient).to receive(:new).and_return(catalogue_service_mock)
+
+          get "/catalog/0000/offsite?url=http://opac.newsbank.com/select/shaw/35846"
+
+          expect(catalogue_service_mock).to have_received(:post_stats).with(anything)
         end
       end
 
@@ -44,7 +55,16 @@ RSpec.describe "Offsite redirect", :request do
 
         it "redirects to the 'url'" do
           get "/catalog/0000/offsite?url=http://opac.newsbank.com/select/shaw/35846"
+
           expect(request).to redirect_to("http://opac.newsbank.com/select/shaw/35846")
+        end
+
+        it "posts stats" do
+          allow(CatalogueServicesClient).to receive(:new).and_return(catalogue_service_mock)
+
+          get "/catalog/0000/offsite?url=http://opac.newsbank.com/select/shaw/35846"
+
+          expect(catalogue_service_mock).to have_received(:post_stats).with(anything)
         end
       end
 
@@ -74,9 +94,18 @@ RSpec.describe "Offsite redirect", :request do
                 Time.use_zone("Canberra") do
                   travel_to Time.zone.local(2022, 11, 28, 0, 0, 0) do
                     get "/catalog/0000/offsite?url=http://www.macquariedictionary.com.au/login"
+
                     expect(request).to redirect_to("https://ezproxy.example.com/login?user=user&ticket=60d52eca002749aef4d50486c91c2a6d%24u1669554000&url=http://www.macquariedictionary.com.au/login")
                   end
                 end
+              end
+
+              it "posts stats" do
+                allow(CatalogueServicesClient).to receive(:new).and_return(catalogue_service_mock)
+
+                get "/catalog/0000/offsite?url=http://www.macquariedictionary.com.au/login"
+
+                expect(catalogue_service_mock).to have_received(:post_stats).with(anything)
               end
             end
           end

--- a/spec/services/catalogue_services_client_spec.rb
+++ b/spec/services/catalogue_services_client_spec.rb
@@ -74,4 +74,46 @@ RSpec.describe CatalogueServicesClient, type: :request do
       end
     end
   end
+
+  describe "#post_stats" do
+    context "when unable to post stats" do
+      before do
+        WebMock.stub_request(:post, /catservices.test\/catalogue-services\/log\/message/)
+          .with(
+            headers: {
+              "Accept" => "*/*",
+              "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+              "Content-Type" => "application/json"
+            }
+          )
+          .to_raise(StandardError)
+      end
+
+      let(:stats) { EresourcesStats.new({entry: {"remoteaccess" => "yes", "title" => "test title"}}, "external") }
+
+      it "returns nil" do
+        expect { service.post_stats(stats) }.not_to raise_error
+      end
+    end
+
+    context "when non-200 response" do
+      before do
+        WebMock.stub_request(:post, /catservices.test\/catalogue-services\/log\/message/)
+          .with(
+            headers: {
+              "Accept" => "*/*",
+              "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+              "Content-Type" => "application/json"
+            }
+          )
+          .to_return(status: 501, body: "", headers: {})
+      end
+
+      let(:stats) { EresourcesStats.new({entry: {"remoteaccess" => "yes", "title" => "test title"}}, "external") }
+
+      it "returns nil" do
+        expect { service.post_stats(stats) }.not_to raise_error
+      end
+    end
+  end
 end

--- a/spec/services/eresources_config_service_spec.rb
+++ b/spec/services/eresources_config_service_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EresourcesConfigService, type: :request do
+  subject(:service) { described_class.new }
+
+  describe "#fetch_config" do
+    context "when unable to connect to config endpoint" do
+      it "returns nil" do
+        stub_const("ENV", ENV.to_hash.merge("ERESOURCES_CONFIG_URL" => "http://eresource-manager.example.com/service-fail"))
+
+        expect(service.fetch_config).to be_nil
+      end
+    end
+
+    context "when non-200 response" do
+      it "returns nil" do
+        stub_const("ENV", ENV.to_hash.merge("ERESOURCES_CONFIG_URL" => "http://eresource-manager.example.com/service-error"))
+
+        expect(service.fetch_config).to be_nil
+      end
+    end
+  end
+end

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -18,7 +18,7 @@ RSpec.configure do |config|
       )
       .to_return(status: 200, body: eresource_config, headers: {})
 
-    WebMock.stub_request(:get, "http://eresource-manager.example.com/service-fail")
+    WebMock.stub_request(:get, "http://eresource-manager.example.com/service-error")
       .with(
         headers: {
           "Accept" => "application/json",
@@ -26,6 +26,15 @@ RSpec.configure do |config|
         }
       )
       .to_return(status: 500, body: "", headers: {})
+
+    WebMock.stub_request(:get, "http://eresource-manager.example.com/service-fail")
+      .with(
+        headers: {
+          "Accept" => "application/json",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+        }
+      )
+      .to_raise(StandardError)
 
     WebMock.stub_request(:get, /solr:8983/)
       .with(
@@ -238,5 +247,15 @@ RSpec.configure do |config|
         }
       )
       .to_return(status: 200, body: "{\"requestLimitReached\": \"false\"}", headers: {})
+
+    WebMock.stub_request(:post, /catservices.test\/catalogue-services\/log\/message/)
+      .with(
+        headers: {
+          "Accept" => "*/*",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Content-Type" => "application/json"
+        }
+      )
+      .to_return(status: 200, body: "", headers: {})
   end
 end


### PR DESCRIPTION
Post stats to catalogue-services for reporting.

Also configures rack-miniprofiler to store stats into Redis and refactors the fetching of the eResources config JSON into a separate service.