### PR TITLE
fix: change limiters and expanders params for EDS API

### DIFF
--- a/app/search_engines/bento_search/eds_api_engine.rb
+++ b/app/search_engines/bento_search/eds_api_engine.rb
@@ -27,7 +27,10 @@ module BentoSearch
           query: q,
           results_per_page: args[:per_page],
           highlight: false,
-          include_facets: false
+          include_facets: false,
+          limiters: ["FT1:y"],
+          expanders: ["fulltext"],
+          auto_suggest: false
         }
 
         if args[:search_field]

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -157,7 +157,7 @@ RSpec.configure do |config|
 
     WebMock.stub_request(:post, /eds-api.ebscohost.com\/edsapi\/rest\/Search/)
       .with(
-        body: "{\"SearchCriteria\":{\"Queries\":[{\"Term\":\"hydrogen\"}],\"SearchMode\":\"bool\",\"IncludeFacets\":\"n\",\"FacetFilters\":[],\"Limiters\":[],\"Sort\":\"relevance\",\"PublicationId\":null,\"RelatedContent\":[\"emp\"],\"AutoSuggest\":\"y\",\"Expanders\":[\"fulltext\"],\"AutoCorrect\":\"n\"},\"RetrievalCriteria\":{\"View\":\"brief\",\"ResultsPerPage\":3,\"PageNumber\":1,\"Highlight\":false,\"IncludeImageQuickView\":false},\"Actions\":[\"GoToPage(1)\"],\"Comment\":\"\"}",
+        body: "{\"SearchCriteria\":{\"Queries\":[{\"Term\":\"hydrogen\"}],\"SearchMode\":\"bool\",\"IncludeFacets\":\"n\",\"FacetFilters\":[],\"Limiters\":[{\"Id\":\"FT1\",\"Values\":[\"y\"]}],\"Sort\":\"relevance\",\"PublicationId\":null,\"RelatedContent\":[\"emp\"],\"AutoSuggest\":\"n\",\"Expanders\":[\"fulltext\"],\"AutoCorrect\":\"n\"},\"RetrievalCriteria\":{\"View\":\"brief\",\"ResultsPerPage\":3,\"PageNumber\":1,\"Highlight\":false,\"IncludeImageQuickView\":false},\"Actions\":[\"GoToPage(1)\"],\"Comment\":\"\"}",
         headers: {
           "Accept" => "application/json",
           "X-Authenticationtoken" => "AGPGzYCzk-NO9_ueZr4gxTl-MP2cQWQ1zUR7IkN1c3RvbWVySWQiOiJzODQyMzUxNiIsIkdyb3VwSWQiOiJtYWluIn0",
@@ -170,7 +170,7 @@ RSpec.configure do |config|
 
     WebMock.stub_request(:post, /eds-api.ebscohost.com\/edsapi\/rest\/Search/)
       .with(
-        body: "{\"SearchCriteria\":{\"Queries\":[{\"FieldCode\":\"TI\",\"Term\":\"hydrogen\"}],\"SearchMode\":\"bool\",\"IncludeFacets\":\"n\",\"FacetFilters\":[],\"Limiters\":[],\"Sort\":\"relevance\",\"PublicationId\":null,\"RelatedContent\":[\"emp\"],\"AutoSuggest\":\"y\",\"Expanders\":[\"fulltext\"],\"AutoCorrect\":\"n\"},\"RetrievalCriteria\":{\"View\":\"brief\",\"ResultsPerPage\":3,\"PageNumber\":1,\"Highlight\":false,\"IncludeImageQuickView\":false},\"Actions\":[\"GoToPage(1)\"],\"Comment\":\"\"}",
+        body: "{\"SearchCriteria\":{\"Queries\":[{\"FieldCode\":\"TI\",\"Term\":\"hydrogen\"}],\"SearchMode\":\"bool\",\"IncludeFacets\":\"n\",\"FacetFilters\":[],\"Limiters\":[{\"Id\":\"FT1\",\"Values\":[\"y\"]}],\"Sort\":\"relevance\",\"PublicationId\":null,\"RelatedContent\":[\"emp\"],\"AutoSuggest\":\"n\",\"Expanders\":[\"fulltext\"],\"AutoCorrect\":\"n\"},\"RetrievalCriteria\":{\"View\":\"brief\",\"ResultsPerPage\":3,\"PageNumber\":1,\"Highlight\":false,\"IncludeImageQuickView\":false},\"Actions\":[\"GoToPage(1)\"],\"Comment\":\"\"}",
         headers: {
           "Accept" => "application/json",
           "X-Authenticationtoken" => "AGPGzYCzk-NO9_ueZr4gxTl-MP2cQWQ1zUR7IkN1c3RvbWVySWQiOiJzODQyMzUxNiIsIkdyb3VwSWQiOiJtYWluIn0",

--- a/spec/system/bento_search_spec.rb
+++ b/spec/system/bento_search_spec.rb
@@ -48,7 +48,6 @@ RSpec.describe "Bento Search" do
     before do
       WebMock.stub_request(:post, /eds-api.ebscohost.com\/edsapi\/rest\/Search/)
         .with(
-          body: "{\"SearchCriteria\":{\"Queries\":[{\"Term\":\"hydrogen\"}],\"SearchMode\":\"bool\",\"IncludeFacets\":\"n\",\"FacetFilters\":[],\"Limiters\":[],\"Sort\":\"relevance\",\"PublicationId\":null,\"RelatedContent\":[\"emp\"],\"AutoSuggest\":\"y\",\"Expanders\":[\"fulltext\"],\"AutoCorrect\":\"n\"},\"RetrievalCriteria\":{\"View\":\"brief\",\"ResultsPerPage\":3,\"PageNumber\":1,\"Highlight\":false,\"IncludeImageQuickView\":false},\"Actions\":[\"GoToPage(1)\"],\"Comment\":\"\"}",
           headers: {
             "Accept" => "application/json",
             "X-Authenticationtoken" => "AGPGzYCzk-NO9_ueZr4gxTl-MP2cQWQ1zUR7IkN1c3RvbWVySWQiOiJzODQyMzUxNiIsIkdyb3VwSWQiOiJtYWluIn0",


### PR DESCRIPTION
Matches the default search configuration in eResources, so the number of results will match when clicking through to eResources from the bento search.