### PR TITLE
chore: pull in patron Keycloak login changes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 
 GIT
   remote: https://github.com/nla/nla-blacklight_common
-  revision: 2f06439c9a3a23d09f671eef02d974ba96a9deed
+  revision: d5c1b64dfc034d60c1eb5c12f25523c491160414
   branch: main
   specs:
     nla-blacklight_common (0.1.8)
@@ -635,7 +635,7 @@ GEM
       activerecord (>= 5.2)
     summon (2.0.5)
       json
-    thor (1.2.2)
+    thor (1.3.0)
     tilt (2.3.0)
     timeout (0.4.0)
     traject (3.8.1)


### PR DESCRIPTION
Changes are feature flagged behind `KC_PATRON_REALM` environment variable, so should display and function using UserReg until Keycloak patron realm configuration is configured.