### PR TITLE
feat: remove seconds from timestamp and change label to "Date"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,7 @@ gem "faraday-http-cache"
 gem "uri", "~> 0.12.1"
 
 # Before a release, point these gem at a tag, instead of the `main` branch.
-gem "nla-blacklight_common", git: "https://github.com/nla/nla-blacklight_common", tag: "0.1.9"
+gem "nla-blacklight_common", git: "https://github.com/nla/nla-blacklight_common", branch: "main"
 gem "bento_search", git: "https://github.com/nla/bento_search.git", tag: "0.0.1"
 
 # For local development, comment out above ⤴️ and uncomment below ⤵️. Assumes this directory and

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 GIT
   remote: https://github.com/nla/nla-blacklight_common
   revision: f8c7dcaaa09614180c8718107ab4d9a84f0bc01a
-  tag: 0.1.9
+  branch: main
   specs:
     nla-blacklight_common (0.1.9)
       activerecord-session_store (~> 2.0)
@@ -403,7 +403,7 @@ GEM
     namae (1.1.1)
     net-http-persistent (4.0.2)
       connection_pool (~> 2.2)
-    net-imap (0.4.1)
+    net-imap (0.4.2)
       date
       net-protocol
     net-pop (0.1.2)

--- a/app/models/request_detail.rb
+++ b/app/models/request_detail.rb
@@ -19,7 +19,7 @@ class RequestDetail
   end
 
   def request_time
-    @date.strftime("%I:%M:%S%P")
+    @date.strftime("%I:%M%P")
   end
 
   def partial_name

--- a/app/services/catalogue_services_client.rb
+++ b/app/services/catalogue_services_client.rb
@@ -99,11 +99,7 @@ class CatalogueServicesClient
 
     res = conn.get("/catalogue-services/folio/request/#{request_id}?loan=#{loan}")
     if res.status == 200
-      if res.body.present?
-        JSON.parse(res.body.to_json, object_class: OpenStruct)
-      else
-        {}
-      end
+      JSON.parse(res.body.to_json, object_class: OpenStruct)
     else
       message = "Failed to retrieve request details for #{request_id}"
       Rails.logger.error message

--- a/app/views/account/request_details.html.erb
+++ b/app/views/account/request_details.html.erb
@@ -11,7 +11,7 @@
           <% if @details.partial_name != "monographs" %>
             <%= render "account/request_details/#{@details.partial_name}", details: @details %>
           <% end %>
-          <dt class="col-12 col-md-4 text-md-right"><%= t("account.requests.table_column_headings.request_date") %></dt>
+          <dt class="col-12 col-md-4 text-md-right"><%= t("requesting.metadata.request_date") %></dt>
           <dd class="col col-md-8"><%= @details.request_date %><br /><small class="text-muted"><%= @details.request_time %></small></dd>
           <% if @details.patronComments.present? || @details.cancellationReason.present? || @details.cancellationComment.present? %>
             <dt class="col-12 col-md-4 text-md-right"><%= t("requesting.label.notes") %></dt>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,6 +75,7 @@ en:
       supplements: "Supplements:"
       indexes: "Indexes:"
       delivery_conditions: "Delivery Conditions:"
+      request_date: "Date:"
     prompt: "<strong>You are requesting a journal, magazine, newspaper, annual report or other multi-part item. Please use the fields below to tell our staff which issues you would like to request.</strong>"
     prompt_2: "You can use one request for consecutive parts. A separate request must be placed for non-sequential years/volumes or days/months. Requests for large amounts of material may be partially supplied. If you need assistance with this please <a href=\"%{contact_us}\">contact us.</a>"
     multi_box_prompt: "<strong>You are requesting a multiple box collection. Please use the fields below to tell our staff which box or boxes you would like to request.</strong>"
@@ -143,7 +144,7 @@ en:
         title: "Title"
         location: "Pickup location"
         notes: "Notes"
-        request_date: "Requested on"
+        request_date: "Date"
       details:
         heading: "Request Details"
     settings:

--- a/spec/components/request_table_row_component_spec.rb
+++ b/spec/components/request_table_row_component_spec.rb
@@ -48,7 +48,13 @@ RSpec.describe RequestTableRowComponent, type: :component do
     render_inline(described_class.new(request_data))
 
     expect(page).to have_css("td", text: "20 June 2023")
-    expect(page).to have_css("small.text-muted", text: "06:36:33pm")
+    expect(page).to have_css("small.text-muted", text: "06:36pm")
+  end
+
+  it "renders the details modal link" do
+    render_inline(described_class.new(request_data))
+
+    expect(page).to have_css("a[data-blacklight-modal='trigger']")
   end
 
   def request_data

--- a/spec/files/account/request_summary.json
+++ b/spec/files/account/request_summary.json
@@ -6,7 +6,8 @@
       "callNumber": "320.01 L348",
       "status": "Open",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": true
     },
     {
       "requestDate": "2023-07-05T23:23:43.004Z",
@@ -15,7 +16,8 @@
       "callNumber": "910.5 NAT",
       "status": "Open",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": true
     }
   ],
   "readyForCollection": [],
@@ -29,7 +31,8 @@
       "callNumber": "N 2021-2490",
       "status": "Open - Not yet filled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-06-20T08:36:33.000+00:00",
@@ -40,7 +43,8 @@
       "callNumber": "N N 791.43720994 M379",
       "status": "Open - Not yet filled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-06-18T05:27:12.000+00:00",
@@ -50,7 +54,8 @@
       "callNumber": "p p 828.91209 J77",
       "status": "Open - Not yet filled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-05-22T00:30:26.000+00:00",
@@ -59,7 +64,8 @@
       "callNumber": "NX 354",
       "status": "Open - Not yet filled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room - Newspapers and Family History"
+      "pickupServicePoint": "Main Reading Room - Newspapers and Family History",
+      "loan": false
     }
   ],
   "notAvailable": [
@@ -72,7 +78,8 @@
       "callNumber": "N 2021-2490",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-06-20T08:55:16.000+00:00",
@@ -83,7 +90,8 @@
       "callNumber": "N 2021-2490",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-06-20T08:52:15.000+00:00",
@@ -94,7 +102,8 @@
       "callNumber": "N 2021-2490",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-06-18T04:35:59.000+00:00",
@@ -105,7 +114,8 @@
       "callNumber": "N N 919.4 NAT",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-06-18T01:54:09.000+00:00",
@@ -115,7 +125,8 @@
       "callNumber": "S 910.5 NAT",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     }
   ],
   "previousRequests": [
@@ -128,7 +139,8 @@
       "callNumber": "NL NL 919.4 NAT",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-06-18T01:37:21.000+00:00",
@@ -139,7 +151,8 @@
       "callNumber": "N N 919.4 NAT",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-06-18T01:35:40.000+00:00",
@@ -149,7 +162,8 @@
       "callNumber": "S 910.5 NAT",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-06-18T00:34:55.000+00:00",
@@ -160,7 +174,8 @@
       "callNumber": "S 910.5 NAT",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-06-18T00:31:45.000+00:00",
@@ -171,7 +186,8 @@
       "callNumber": "S 910.5 NAT",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-06-18T00:30:07.000+00:00",
@@ -182,7 +198,8 @@
       "callNumber": "S 910.5 NAT",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-06-18T00:29:30.000+00:00",
@@ -193,7 +210,8 @@
       "callNumber": "S 910.5 NAT",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-06-18T00:28:49.000+00:00",
@@ -204,7 +222,8 @@
       "callNumber": "S 910.5 NAT",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-06-18T00:08:18.000+00:00",
@@ -215,7 +234,8 @@
       "callNumber": "S 910.5 NAT",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-06-17T22:37:01.000+00:00",
@@ -227,7 +247,8 @@
       "callNumber": "HSW 2071",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Special Collections Reading Room"
+      "pickupServicePoint": "Special Collections Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-06-17T22:36:22.000+00:00",
@@ -239,7 +260,8 @@
       "callNumber": "HSW 2071",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Special Collections Reading Room"
+      "pickupServicePoint": "Special Collections Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-06-17T22:33:35.000+00:00",
@@ -251,7 +273,8 @@
       "callNumber": "HSW 2071",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Special Collections Reading Room"
+      "pickupServicePoint": "Special Collections Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-06-17T22:32:42.000+00:00",
@@ -263,7 +286,8 @@
       "callNumber": "HSW 2071",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Special Collections Reading Room"
+      "pickupServicePoint": "Special Collections Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-06-17T22:32:15.000+00:00",
@@ -275,7 +299,8 @@
       "callNumber": "HSW 2071",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Special Collections Reading Room"
+      "pickupServicePoint": "Special Collections Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-06-17T22:31:36.000+00:00",
@@ -287,7 +312,8 @@
       "callNumber": "HSW 2071",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Special Collections Reading Room"
+      "pickupServicePoint": "Special Collections Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-06-17T22:31:06.000+00:00",
@@ -299,7 +325,8 @@
       "callNumber": "HSW 2071",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Special Collections Reading Room"
+      "pickupServicePoint": "Special Collections Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-06-01T03:29:56.000+00:00",
@@ -310,7 +337,8 @@
       "callNumber": "HSW 2071",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Special Collections Reading Room"
+      "pickupServicePoint": "Special Collections Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-06-01T03:28:49.000+00:00",
@@ -321,7 +349,8 @@
       "callNumber": "HSW 2071",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Special Collections Reading Room"
+      "pickupServicePoint": "Special Collections Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-06-01T03:28:11.000+00:00",
@@ -332,7 +361,8 @@
       "callNumber": "HSW 2071",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Special Collections Reading Room"
+      "pickupServicePoint": "Special Collections Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-06-01T03:26:33.000+00:00",
@@ -343,7 +373,8 @@
       "callNumber": "HSW 2071",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Special Collections Reading Room"
+      "pickupServicePoint": "Special Collections Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-06-01T03:13:07.000+00:00",
@@ -353,7 +384,8 @@
       "callNumber": "NKA 1132",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Special Collections Reading Room"
+      "pickupServicePoint": "Special Collections Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-05-23T04:39:23.000+00:00",
@@ -365,7 +397,8 @@
       "callNumber": "S 910.5 NAT",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-05-19T07:30:51.000+00:00",
@@ -376,7 +409,8 @@
       "callNumber": "S 910.5 NAT",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-05-19T07:29:49.000+00:00",
@@ -387,7 +421,8 @@
       "callNumber": "S 910.5 NAT",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-05-19T07:29:24.000+00:00",
@@ -398,7 +433,8 @@
       "callNumber": "S 910.5 NAT",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-05-19T07:26:41.000+00:00",
@@ -409,7 +445,8 @@
       "callNumber": "S 910.5 NAT",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-05-19T07:25:05.000+00:00",
@@ -420,7 +457,8 @@
       "callNumber": "S 910.5 NAT",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-05-19T07:24:46.000+00:00",
@@ -431,7 +469,8 @@
       "callNumber": "S 910.5 NAT",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-05-19T07:23:42.000+00:00",
@@ -442,7 +481,8 @@
       "callNumber": "S 910.5 NAT",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-05-19T06:22:06.000+00:00",
@@ -451,7 +491,8 @@
       "callNumber": "NKA 1132",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Special Collections Reading Room"
+      "pickupServicePoint": "Special Collections Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-05-19T06:17:38.000+00:00",
@@ -460,7 +501,8 @@
       "callNumber": "NKA 1132",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Special Collections Reading Room"
+      "pickupServicePoint": "Special Collections Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-05-19T06:12:18.000+00:00",
@@ -470,7 +512,8 @@
       "callNumber": "NL NL 919.4 NAT",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-05-19T04:52:11.000+00:00",
@@ -479,7 +522,8 @@
       "callNumber": "NKA 1132",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Special Collections Reading Room"
+      "pickupServicePoint": "Special Collections Reading Room",
+      "loan": false
     },
     {
       "requestDate": "2023-05-19T03:12:18.000+00:00",
@@ -491,7 +535,8 @@
       "callNumber": "N 610.6 MED",
       "status": "Closed - Cancelled",
       "requestId": "9bf133e5-39dc-46e1-918b-2617142ff7e4",
-      "pickupServicePoint": "Main Reading Room"
+      "pickupServicePoint": "Main Reading Room",
+      "loan": false
     }
   ],
   "numRequestsRemaining": 11

--- a/spec/files/account/single_request.json
+++ b/spec/files/account/single_request.json
@@ -3,7 +3,7 @@
   "title": "The Mad Max movies / Adrian Martin.",
   "patronComments": "Testing patron comments",
   "instanceId": "4a05cad3-5269-5a5e-90f6-2ab0ccce6861",
-  "yearCaption": "1909",
+  "yearCaption": ["1909"],
   "enumeration": "pbk",
   "chronology": "June, July",
   "callNumber": "N N 791.43720994 M379",

--- a/spec/files/account/single_request_with_cancellation.json
+++ b/spec/files/account/single_request_with_cancellation.json
@@ -3,6 +3,7 @@
   "title": "The Mad Max movies / Adrian Martin.",
   "patronComments": "Testing patron comments",
   "instanceId": "4a05cad3-5269-5a5e-90f6-2ab0ccce6861",
+  "yearCaption": ["1909"],
   "enumeration": "pbk",
   "callNumber": "N N 791.43720994 M379",
   "status": "Open - Not yet filled",

--- a/spec/services/catalogue_services_client_spec.rb
+++ b/spec/services/catalogue_services_client_spec.rb
@@ -75,6 +75,84 @@ RSpec.describe CatalogueServicesClient, type: :request do
     end
   end
 
+  describe "#get_request_summary" do
+    context "when 200 response" do
+      it "returns request summary" do
+        expect(service.get_request_summary(folio_id: "1111")).not_to be_nil
+      end
+    end
+
+    context "when non-200 response" do
+      it "returns a default summary" do
+        WebMock.stub_request(:get, /catservices.test\/catalogue-services\/folio\/user\/.*\/myRequests/)
+          .with(
+            headers: {
+              "Accept" => "*/*",
+              "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+            }
+          )
+          .to_return(status: 404, body: "", headers: {})
+
+        expect(service.get_request_summary(folio_id: "1111")).to eq CatalogueServicesClient::DEFAULT_REQUEST_SUMMARY
+      end
+    end
+
+    context "when unable to connect to service" do
+      it "returns a default summary" do
+        WebMock.stub_request(:get, /catservices.test\/catalogue-services\/folio\/user\/.*\/myRequests/)
+          .with(
+            headers: {
+              "Accept" => "*/*",
+              "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+            }
+          )
+          .to_raise(StandardError)
+
+        expect(service.get_request_summary(folio_id: "1111")).to eq CatalogueServicesClient::DEFAULT_REQUEST_SUMMARY
+      end
+    end
+  end
+
+  describe "#request_details" do
+    context "when 200 response" do
+      it "returns request details" do
+        expect(service.request_details(request_id: "1111", loan: false)).not_to be_nil
+      end
+    end
+
+    context "when non-200 response" do
+      it "raises a RequestDetailsError" do
+        WebMock.stub_request(:get, /catservices.test\/catalogue-services\/folio\/request\/(.*)\?loan=(.*)/)
+          .with(
+            headers: {
+              "Accept" => "*/*",
+              "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+              "User-Agent" => "nla-blacklight/2.9.0"
+            }
+          )
+          .to_return(status: 500, body: "", headers: {})
+
+        expect { service.request_details(request_id: "1111", loan: false) }.to raise_error(RequestDetailsError)
+      end
+    end
+
+    context "when unable to connect to service" do
+      it "raises a RequestDetailsError" do
+        WebMock.stub_request(:get, /catservices.test\/catalogue-services\/folio\/request\/(.*)\?loan=(.*)/)
+          .with(
+            headers: {
+              "Accept" => "*/*",
+              "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+              "User-Agent" => "nla-blacklight/2.9.0"
+            }
+          )
+          .to_raise(StandardError)
+
+        expect { service.request_details(request_id: "1111", loan: false) }.to raise_error(RequestDetailsError)
+      end
+    end
+  end
+
   describe "#post_stats" do
     context "when unable to post stats" do
       before do

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -257,5 +257,17 @@ RSpec.configure do |config|
         }
       )
       .to_return(status: 200, body: "", headers: {})
+
+    request_details = IO.read("spec/files/account/single_request.json")
+
+    WebMock.stub_request(:get, /catservices.test\/catalogue-services\/folio\/request\/(.*)\?loan=(.*)/)
+      .with(
+        headers: {
+          "Accept" => "*/*",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "User-Agent" => "nla-blacklight/2.9.0"
+        }
+      )
+      .to_return(status: 200, body: request_details, headers: {})
   end
 end

--- a/spec/system/request_summary_spec.rb
+++ b/spec/system/request_summary_spec.rb
@@ -1,0 +1,53 @@
+require "system_helper"
+
+RSpec.describe "Request summary" do
+  context "when logged in" do
+    before do
+      visit root_path
+      click_link "Login"
+
+      fill_in "user_username", with: "bltest"
+      fill_in "user_password", with: "test"
+      click_button "Login"
+    end
+
+    it "displays the request summary" do
+      visit account_requests_path
+
+      expect(page).to have_css("a.active", text: "blacklight test")
+
+      expect(page).to have_css("caption", text: /Checked out/)
+      expect(page).to have_css("caption", text: /Ready for collection/)
+      expect(page).to have_css("caption", text: /Not available/)
+      expect(page).to have_css("caption", text: /Items requested/)
+      expect(page).to have_css("caption", text: /Previous requests/)
+    end
+
+    it "displays the request details" do
+      visit request_details_path("d7746c53-7746-4b0e-8382-5261aa9bcecb", loan: false)
+
+      expect(page).to have_css("h1", text: "Request Details")
+      expect(page).to have_css("h3", text: "The Mad Max movies / Adrian Martin.")
+
+      expect(page).to have_css("dt", text: "Collect From:")
+      expect(page).to have_css("dd", text: "Main Reading Room")
+
+      expect(page).to have_css("dt", text: "Date:")
+      expect(page).to have_css("dd", text: "20 June 2023")
+      expect(page).to have_css("small", text: "06:36pm")
+
+      expect(page).to have_css("dt", text: "Notes:")
+      expect(page).to have_css("dd", text: "Testing patron comments")
+    end
+  end
+
+  context "when not logged in" do
+    it "redirects to the login page" do
+      visit account_requests_path
+
+      expect(page).to have_content("Login")
+      expect(page).to have_content("User ID")
+      expect(page).to have_content("Family Name")
+    end
+  end
+end


### PR DESCRIPTION
Changes the label and table heading for the request details date to "Date" and removes the seconds from the timestamp.

Changes also applied to request summary and request details modal.