### PR TITLE
fix: increase email field length to max length in Keycloak

### DIFF
--- a/app/components/user_details_field_component.html.erb
+++ b/app/components/user_details_field_component.html.erb
@@ -1,5 +1,5 @@
 <div class="col-sm-3 py-1 align-middle settings-label" id="<%= "#{@attribute}-label" %>"><%= @label %>:</div>
-<div class="col-sm-3 py-1 align-middle">
+<div class="col-sm-3 py-1 align-middle text-break">
   <%= @value || "&nbsp;".html_safe %>
 </div>
 <div class="col">

--- a/app/services/catalogue_services_client.rb
+++ b/app/services/catalogue_services_client.rb
@@ -154,12 +154,12 @@ class CatalogueServicesClient
       if res.body.present? && res.body["totalRecords"].to_i == 1
         folio_details = res.body["users"]&.first
         {
-          first_name: folio_details&.dig("personal", "firstName") || "",
-          last_name: folio_details&.dig("personal", "lastName") || "",
-          email: folio_details&.dig("personal", "email") || "",
-          phone: folio_details&.dig("personal", "phone") || "",
-          mobile_phone: folio_details&.dig("personal", "mobilePhone") || "",
-          postcode: folio_details&.dig("personal", "addresses")&.first&.[]("postalCode") || ""
+          first_name: folio_details&.dig("personal", "firstName"),
+          last_name: folio_details&.dig("personal", "lastName"),
+          email: folio_details&.dig("personal", "email"),
+          phone: folio_details&.dig("personal", "phone"),
+          mobile_phone: folio_details&.dig("personal", "mobilePhone"),
+          postcode: folio_details&.dig("personal", "addresses")&.first&.[]("postalCode")
         }
       else
         {}

--- a/app/views/account/profile/_form.html.erb
+++ b/app/views/account/profile/_form.html.erb
@@ -25,7 +25,7 @@
         <div class="form-group row">
           <%= f.label :email, "New #{t("account.settings.email.change_text")}:", class: "col-sm-3 col-form-label" %>
           <div class="col-sm-6">
-            <%= f.text_field :email, class: "form-control", maxlength: 35, autocomplete: "email" %>
+            <%= f.text_field :email, class: "form-control", maxlength: 255, autocomplete: "email" %>
           </div>
         </div>
       <% end %>


### PR DESCRIPTION
Increased the max lenght accepted by the email form field to the maximum accepted by Keycloak. Also added the `text-break` class to the value column on the profile details page to void overlapping the edit links.