### PR TITLE
fix: set headers to not cache any pages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -374,7 +374,7 @@ GEM
       activesupport (>= 4)
       railties (>= 4)
       request_store (~> 1.0)
-    loofah (2.21.4)
+    loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.8.1)
@@ -406,7 +406,7 @@ GEM
     namae (1.1.1)
     net-http-persistent (4.0.2)
       connection_pool (~> 2.2)
-    net-imap (0.4.4)
+    net-imap (0.4.5)
       date
       net-protocol
     net-pop (0.1.2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :store_user_location!, if: :storable_location?
-  before_action :authorize_profile
+  before_action :set_cache_headers
 
   # defines #new_session_path(scope) to allow correct redirection when only using OmniAuth
   include AuthSessionConcern
@@ -15,6 +15,12 @@ class ApplicationController < ActionController::Base
   append_view_path "#{Rails.root}/app/components/"
 
   private
+
+  def set_cache_headers
+    response.headers["Cache-Control"] = "no-cache, no-store"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "Mon, 01 Jan 1990 00:00:00 GMT"
+  end
 
   # Its important that the location is NOT stored if:
   # - The request method is not GET (non idempotent)
@@ -44,10 +50,6 @@ class ApplicationController < ActionController::Base
     store_location_for(:user, request.fullpath)
   rescue
     Rails.logger.debug { "Unable to store location for user: #{request.fullpath}" }
-  end
-
-  def authorize_profile
-    Rack::MiniProfiler.authorize_request if Whitelist.instance.location(request) == :staff && ENV.fetch("ENABLE_PROFILER") { "n" } == "y"
   end
   # :nocov:
 end

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,64 +1,62 @@
 <% content_for(:page_header) {t("headings.search") } %>
-<%= cache do %>
-  <section class="collection-search mb-5">
-    <p class="h5"><%= t('blacklight.collection_search.description.p1') %></p>
-    <p class="h5 mb-3"><%= t('blacklight.collection_search.description.p2') %></p>
-    <div class="collection-search-box px-4 py-5">
-      <h2><%= t('blacklight.collection_search.title') %></h2>
-      <%= render "search/home_search_form" %>
-    </div>
-  </section>
-  <div class="card-deck">
-    <section class="card catalogue-search">
-      <div class="image-container"><%= image_tag "catalogue.jpg", class: "card-img-top", alt: "Books" %></div>
-      <div class="card-body">
-        <h2 class="card-title h4"><%= link_to t("blacklight.catalogue.title"), "/catalog", class: "stretched-link" %></h2>
-        <p class="card-text"><%= t('blacklight.catalogue.description') %></p>
-      </div>
-    </section>
-    <section class="card eresources-search">
-      <div class="image-container"><%= image_tag "eresources.jpg", class: "card-img-top", alt: "Lady using computer" %></div>
-      <div class="card-body">
-        <h2 class="card-title h4"><%= link_to t("blacklight.eresources.title"), "https://www.nla.gov.au/eresources", class: "stretched-link" %></h2>
-        <p class="card-text"><%= t('blacklight.eresources.description') %></p>
-      </div>
-    </section>
-    <section class="card finding-aids-search">
-      <div class="image-container"><%= image_tag "finding-aids.jpg", class: "card-img-top", alt: "Trolley with manuscript boxes" %></div>
-      <div class="card-body">
-        <h2 class="card-title h4"><%= link_to t("blacklight.finding_aids.title"), "/finding-aids", class: "stretched-link" %></h2>
-        <p class="card-text"><%= t('blacklight.finding_aids.description') %></p>
-      </div>
-    </section>
+<section class="collection-search mb-5">
+  <p class="h5"><%= t('blacklight.collection_search.description.p1') %></p>
+  <p class="h5 mb-3"><%= t('blacklight.collection_search.description.p2') %></p>
+  <div class="collection-search-box px-4 py-5">
+    <h2><%= t('blacklight.collection_search.title') %></h2>
+    <%= render "search/home_search_form" %>
   </div>
-  <section class="library-card row no-gutters my-5">
-    <div class="col-lg-6">
-      <div>
-        <%= image_tag "join-us.jpg", class: "w-100", alt: "Foyer of the National Library of Australia" %>
-      </div>
-    </div>
-    <div class="col-lg-6 px-3">
-      <h2 class="mt-3 h4"><%= t('blacklight.library_card.title') %></h2>
-
-      <p><%= t('blacklight.library_card.intro.p1') %></p>
-      <p><%= t('blacklight.library_card.intro.p2') %></p>
-      <p><%= link_to t("blacklight.library_card.button"), "https://www.nla.gov.au/getalibrarycard/registration", class: "btn btn-outline-secondary arrow-after" %></p>
+</section>
+<div class="card-deck">
+  <section class="card catalogue-search">
+    <div class="image-container"><%= image_tag "catalogue.jpg", class: "card-img-top", alt: "Books" %></div>
+    <div class="card-body">
+      <h2 class="card-title h4"><%= link_to t("blacklight.catalogue.title"), "/catalog", class: "stretched-link" %></h2>
+      <p class="card-text"><%= t('blacklight.catalogue.description') %></p>
     </div>
   </section>
-
-  <%# This is the same panel shown in the Rails welcome template %>
-  <% if Rails.env.development? || Rails.env.test? %>
-    <div id="about" class="card">
-      <h6 class="card-header collapsed collapse-toggle" data-toggle="collapse" data-target="#about-content"><a href="/rails/info/properties">About this application environment</a></h6>
-      <div id="about-content" class="card-body collapse"></div>
+  <section class="card eresources-search">
+    <div class="image-container"><%= image_tag "eresources.jpg", class: "card-img-top", alt: "Lady using computer" %></div>
+    <div class="card-body">
+      <h2 class="card-title h4"><%= link_to t("blacklight.eresources.title"), "https://www.nla.gov.au/eresources", class: "stretched-link" %></h2>
+      <p class="card-text"><%= t('blacklight.eresources.description') %></p>
     </div>
-  <% end %>
+  </section>
+  <section class="card finding-aids-search">
+    <div class="image-container"><%= image_tag "finding-aids.jpg", class: "card-img-top", alt: "Trolley with manuscript boxes" %></div>
+    <div class="card-body">
+      <h2 class="card-title h4"><%= link_to t("blacklight.finding_aids.title"), "/finding-aids", class: "stretched-link" %></h2>
+      <p class="card-text"><%= t('blacklight.finding_aids.description') %></p>
+    </div>
+  </section>
+</div>
+<section class="library-card row no-gutters my-5">
+  <div class="col-lg-6">
+    <div>
+      <%= image_tag "join-us.jpg", class: "w-100", alt: "Foyer of the National Library of Australia" %>
+    </div>
+  </div>
+  <div class="col-lg-6 px-3">
+    <h2 class="mt-3 h4"><%= t('blacklight.library_card.title') %></h2>
 
-  <script>
-    Blacklight.onLoad(function() {
-      $('#about .card-header').one('click', function() {
-        $($(this).data('target')).load($(this).find('a').attr('href'));
-      });
-    });
-  </script>
+    <p><%= t('blacklight.library_card.intro.p1') %></p>
+    <p><%= t('blacklight.library_card.intro.p2') %></p>
+    <p><%= link_to t("blacklight.library_card.button"), "https://www.nla.gov.au/getalibrarycard/registration", class: "btn btn-outline-secondary arrow-after" %></p>
+  </div>
+</section>
+
+<%# This is the same panel shown in the Rails welcome template %>
+<% if Rails.env.development? || Rails.env.test? %>
+  <div id="about" class="card">
+    <h6 class="card-header collapsed collapse-toggle" data-toggle="collapse" data-target="#about-content"><a href="/rails/info/properties">About this application environment</a></h6>
+    <div id="about-content" class="card-body collapse"></div>
+  </div>
 <% end %>
+
+<script>
+  Blacklight.onLoad(function() {
+    $('#about .card-header').one('click', function() {
+      $($(this).data('target')).load($(this).find('a').attr('href'));
+    });
+  });
+</script>


### PR DESCRIPTION
Tell the browser not to cache any pages via the 'Cache-Control', 'Pragma' and 'Expires' headers. Of course the user can still change the browser settings to ignore these headers if they want to.