### PR TITLE
fix!(solr): single document search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,7 +93,7 @@ gem "ebsco-eds", "~> 1.1", ">= 1.1.5"
 gem "email_validator", "~> 2.2"
 gem "phonelib", "~> 0.8.4"
 
-gem "nla-blacklight_common", git: "https://github.com/nla/nla-blacklight_common", branch: "fix/single-document-search"
+gem "nla-blacklight_common", git: "https://github.com/nla/nla-blacklight_common", branch: "main"
 gem "bento_search", git: "https://github.com/nla/bento_search.git", tag: "0.0.1"
 gem "blacklight_range_limit", git: "https://github.com/nla/blacklight_range_limit", branch: "main"
 # For local development, comment out above ⤴️ and uncomment below ⤵️

--- a/Gemfile
+++ b/Gemfile
@@ -93,7 +93,7 @@ gem "ebsco-eds", "~> 1.1", ">= 1.1.5"
 gem "email_validator", "~> 2.2"
 gem "phonelib", "~> 0.8.4"
 
-gem "nla-blacklight_common", git: "https://github.com/nla/nla-blacklight_common", branch: "feat/upgrade"
+gem "nla-blacklight_common", git: "https://github.com/nla/nla-blacklight_common", branch: "fix/single-document-search"
 gem "bento_search", git: "https://github.com/nla/bento_search.git", tag: "0.0.1"
 gem "blacklight_range_limit", git: "https://github.com/nla/blacklight_range_limit", branch: "main"
 # For local development, comment out above ⤴️ and uncomment below ⤵️

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,8 +27,8 @@ GIT
 
 GIT
   remote: https://github.com/nla/nla-blacklight_common
-  revision: 1d7fe29bdb08fb13b02ab33f69a87340ac79b277
-  branch: feat/upgrade
+  revision: 5d4fb5d0142ac8e1b3a3741a4f2b6569c9cab0ad
+  branch: fix/single-document-search
   specs:
     nla-blacklight_common (0.1.12)
       activerecord-session_store (~> 2.0)
@@ -182,7 +182,7 @@ GEM
     citeproc-ruby (1.1.13)
       citeproc (~> 1.0, >= 1.0.9)
       csl (~> 1.5)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.2.3)
     confstruct (1.1.0)
       hashie (>= 3.3, < 5)
     connection_pool (2.4.1)
@@ -386,7 +386,7 @@ GEM
     mini_histogram (0.3.1)
     mini_mime (1.1.5)
     minitar (0.9)
-    minitest (5.21.1)
+    minitest (5.21.2)
     mock_redis (0.39.0)
     msgpack (1.7.2)
     multi_json (1.15.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,8 +27,8 @@ GIT
 
 GIT
   remote: https://github.com/nla/nla-blacklight_common
-  revision: 5d4fb5d0142ac8e1b3a3741a4f2b6569c9cab0ad
-  branch: fix/single-document-search
+  revision: ed0d71bcdcccc599be3fc00a6970ca368c93e8d4
+  branch: main
   specs:
     nla-blacklight_common (0.1.12)
       activerecord-session_store (~> 2.0)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "blacklight/solr_cloud/repository"
+require "nla/solr_cloud/repository"
 
 class CatalogController < ApplicationController
   include Blacklight::Catalog
@@ -40,7 +40,7 @@ class CatalogController < ApplicationController
     #
     ## Class for sending and receiving requests from a search index
     if ENV["ZK_HOST"].present? && ENV["SOLR_COLLECTION"].present?
-      config.repository_class = Blacklight::SolrCloud::Repository
+      config.repository_class = Nla::SolrCloud::Repository
     end
     #
     ## Class for converting Blacklight's url parameters to into request parameters for the search index
@@ -66,8 +66,15 @@ class CatalogController < ApplicationController
     }
 
     # solr path which will be added to solr base url before the other solr params.
-    # config.solr_path = 'select'
-    # config.document_solr_path = 'get'
+    config.solr_path = "select"
+    config.document_solr_path = "select"
+
+    # solr parameters to send on single-document requests to Solr.
+    # The "q" param is formatted in Blacklight::SolrCloud::Repository.find to search the "id" field.
+    config.document_unique_id_param = "q"
+    # These are sent by default to ensure all document fields are returned.
+    # Facets, spellcheck and response header are omitted, since they're not needed.
+    config.default_document_solr_params = {fl: "*", facet: "false", spellcheck: "false", omitHeader: "true"}
 
     # set to nil otherwise, advanced search will expect a Solr JSON DSL query handler at path "advanced" to exist
     config.json_solr_path = nil

--- a/app/models/request_detail.rb
+++ b/app/models/request_detail.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "blacklight"
-require "blacklight/solr_cloud/repository"
+require "nla/solr_cloud/repository"
 
 class RequestDetail
   include ActiveModel::Model

--- a/app/services/related_records_service.rb
+++ b/app/services/related_records_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "blacklight"
-require "blacklight/solr_cloud/repository"
+require "nla/solr_cloud/repository"
 
 class RelatedRecordsService
   def fetch_count(id, blacklight_config)


### PR DESCRIPTION
Depends on https://github.com/nla/nla-blacklight_common/pull/59

Pulls in changes from common lib and configures Blacklight to use /select instead of /get for single document search and pass some extra default params to avoid returning the response header, spellcheck and facets.