### PR TITLE
fix: remove trailing slash from urlstem when matching root url

### DIFF
--- a/app/models/eresources.rb
+++ b/app/models/eresources.rb
@@ -15,7 +15,14 @@ class Eresources
     result = {}
     @entries&.each do |entry|
       entry["urlstem"].each do |stem|
-        if url.start_with?(stem.strip)
+        clean_stem = stem.strip
+
+        # If the urlstem ends with a '/', we need to check if the url to match starts with the
+        # urlstem minus the trailing '/' in case it is the root URL.
+        # e.g. urlstem = "https://www.example.com/" and url = "https://www.example.com"
+        if url.start_with?(clean_stem) ||
+            (clean_stem.end_with?("/") && url.start_with?(clean_stem[0..-2]))
+
           result = if entry["remoteurl"].present?
             {type: "remoteurl", url: url_append(entry["remoteurl"], "NLAOriginalUrl=#{url}"), entry: entry}
           else

--- a/spec/models/eresources_spec.rb
+++ b/spec/models/eresources_spec.rb
@@ -44,6 +44,18 @@ RSpec.describe Eresources do
   end
 
   describe "#known_url" do
+    context "when urlstem ends with a '/'" do
+      subject(:eresources_link) { described_class.new.known_url("http://m.worldbk.com") }
+
+      let(:entry) { {"remoteaccess" => "yes", "remoteurl" => "", "title" => "World Book Online", "urlstem" => %w[http://www.worldbookonline.com http://m.worldbk.com/]} }
+
+      it "generates an EZProxy link" do
+        stub_const("ENV", ENV.to_hash.merge("ERESOURCES_CONFIG_URL" => "http://eresource-manager.example.com"))
+
+        expect(eresources_link).to eq({type: "ezproxy", url: "http://m.worldbk.com", entry: entry})
+      end
+    end
+
     context "when it is a known eResource with no remote URL" do
       subject(:eresources_link) { described_class.new.known_url("http://m.worldbk.com/") }
 


### PR DESCRIPTION
When an eResources JSON record's `urlstem` contains a trailing slash, it will not match root URLs that don't have this slash and Blacklight will display the record not found page.

e.g. The url "https://example.com" does not start with the `urlstem` "https://example.com/", but they're effectively the same root URL.

To avoid this, this change adds an additional check to see if the url starts with the `urlstem` without the trailing slash.