### PR TITLE
feat: disable login during FOLIO updates

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -79,5 +79,5 @@ PATRON_UPGRADE_URL="define PATRON_UPGRADE_URL"
 #EMAIL_2FA_ACTION="define EMAIL_2FA_ACTION"
 #ABOUT_2FA_URL="define ABOUT_2FA_URL"
 
-# disable requesting
-DISABLE_REQUESTING=
+# disable functionality during FOLIO updates
+FOLIO_UPDATE_IN_PROGRESS=

--- a/.env.staging
+++ b/.env.staging
@@ -67,5 +67,5 @@ THUMBNAIL_SERVICE_API_BASE_URL="define THUMBNAIL_SERVICE_API_BASE_URL"
 # Patron Keycloak migration
 PATRON_UPGRADE_URL="define PATRON_UPGRADE_URL"
 
-# disable requesting
-DISABLE_REQUESTING=
+# disable functionality during FOLIO updates
+FOLIO_UPDATE_IN_PROGRESS=

--- a/.env.test
+++ b/.env.test
@@ -57,5 +57,5 @@ COPYRIGHT_CONTACT_URL=https://test.nla.gov.au/contact-us
 # Copies Direct
 COPIES_DIRECT_URL=https://test.nla.gov.au/copies-direct
 
-# disable requesting
-DISABLE_REQUESTING=
+# disable functionality during FOLIO updates
+FOLIO_UPDATE_IN_PROGRESS=

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ GIT
 
 GIT
   remote: https://github.com/nla/nla-blacklight_common
-  revision: 90eea4c1e63bd82d324d80643efa4542dfdd2edc
+  revision: 50d490cf36c87792258f7e4ca9e9cec73e760f7b
   branch: main
   specs:
     nla-blacklight_common (0.2.1)
@@ -122,7 +122,7 @@ GEM
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     aes_key_wrap (1.1.0)
-    annotaterb (4.7.1)
+    annotaterb (4.8.0)
     anyway_config (2.6.3)
       ruby-next-core (~> 1.0)
     ast (2.4.2)

--- a/app/helpers/request_item_helper.rb
+++ b/app/helpers/request_item_helper.rb
@@ -4,7 +4,7 @@ module RequestItemHelper
   ELECTRONIC_RESOURCE_CALL_NUMBERS = ["ELECTRONIC RESOURCE", "INTERNET"].freeze
 
   def render_request?(document)
-    return false if ENV["DISABLE_REQUESTING"] == "true"
+    return false if ENV["FOLIO_UPDATE_IN_PROGRESS"] == "true"
     !is_ned_item?(document) && !has_no_physical_holdings?(document)
   end
 

--- a/app/views/shared/_user_util_links.html.erb
+++ b/app/views/shared/_user_util_links.html.erb
@@ -7,7 +7,7 @@
       <li class="nav-item dropdown">
         <%= link_to current_user, "#", class: "nav-link dropdown-toggle #{active_link_class_controller(%w[account bookmarks])}", id: "navbarDropdown", role: "button", data: {'bs-toggle': "dropdown"}, aria: {haspopup: "true", expanded: "false"} %>
         <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-          <% unless ENV["DISABLE_REQUESTING"] == "true" %>
+          <% unless ENV["FOLIO_UPDATE_IN_PROGRESS"] == "true" %>
             <%= link_to t("account.requests.menu"), account_requests_path, class: "dropdown-item" %>
           <% end %>
           <%= render partial: "blacklight/nav/bookmark" %>
@@ -19,9 +19,11 @@
       <li class="nav-item">
         <%= link_to t("blacklight.header_links.register"), "https://www.nla.gov.au/getting-started/join-us", class: "nav-link" %>
       </li>
-      <li class="nav-item">
-        <%= link_to t('blacklight.header_links.login'), new_user_session_path, class: "nav-link" %>
-      </li>
+      <% unless ENV["FOLIO_UPDATE_IN_PROGRESS"] == "true" %>
+        <li class="nav-item">
+          <%= link_to t('blacklight.header_links.login'), new_user_session_path, class: "nav-link" %>
+        </li>
+      <% end %>
     <% end %>
   <% end %>
 </ul>

--- a/spec/components/catalogue_record_actions_component_spec.rb
+++ b/spec/components/catalogue_record_actions_component_spec.rb
@@ -19,10 +19,10 @@ RSpec.describe CatalogueRecordActionsComponent, type: :component do
     expect(page.text).to include("Request")
   end
 
-  context "when DISABLE_REQUESTING is `true`" do
+  context "when FOLIO_UPDATE_IN_PROGRESS is `true`" do
     it "does not render the request button" do
       allow(ENV).to receive(:[]).and_call_original
-      allow(ENV).to receive(:[]).with("DISABLE_REQUESTING").and_return("true")
+      allow(ENV).to receive(:[]).with("FOLIO_UPDATE_IN_PROGRESS").and_return("true")
 
       render_inline(described_class.new(document: document))
 
@@ -30,10 +30,10 @@ RSpec.describe CatalogueRecordActionsComponent, type: :component do
     end
   end
 
-  context "when DISABLE_REQUESTING is `false`" do
+  context "when FOLIO_UPDATE_IN_PROGRESS is `false`" do
     it "renders the request button" do
       allow(ENV).to receive(:[]).and_call_original
-      allow(ENV).to receive(:[]).with("DISABLE_REQUESTING").and_return("false")
+      allow(ENV).to receive(:[]).with("FOLIO_UPDATE_IN_PROGRESS").and_return("false")
 
       render_inline(described_class.new(document: document))
 
@@ -41,10 +41,10 @@ RSpec.describe CatalogueRecordActionsComponent, type: :component do
     end
   end
 
-  context "when DISABLE_REQUESTING is defined without a value" do
+  context "when FOLIO_UPDATE_IN_PROGRESS is defined without a value" do
     it "renders the request button" do
       allow(ENV).to receive(:[]).and_call_original
-      allow(ENV).to receive(:[]).with("DISABLE_REQUESTING").and_return("")
+      allow(ENV).to receive(:[]).with("FOLIO_UPDATE_IN_PROGRESS").and_return("")
 
       render_inline(described_class.new(document: document))
 
@@ -52,7 +52,7 @@ RSpec.describe CatalogueRecordActionsComponent, type: :component do
     end
   end
 
-  context "when DISABLE_REQUESTING is not defined" do
+  context "when FOLIO_UPDATE_IN_PROGRESS is not defined" do
     it "renders the request button" do
       render_inline(described_class.new(document: document))
 

--- a/spec/components/request_item_component_spec.rb
+++ b/spec/components/request_item_component_spec.rb
@@ -18,10 +18,10 @@ RSpec.describe RequestItemComponent, type: :component do
     expect(page).to have_css("div.holding")
   end
 
-  context "when DISABLE_REQUESTING is `true`" do
+  context "when FOLIO_UPDATE_IN_PROGRESS is `true`" do
     it "does not render the request button" do
       allow(ENV).to receive(:[]).and_call_original
-      allow(ENV).to receive(:[]).with("DISABLE_REQUESTING").and_return("true")
+      allow(ENV).to receive(:[]).with("FOLIO_UPDATE_IN_PROGRESS").and_return("true")
 
       render_inline(described_class.new(document: document))
 
@@ -29,10 +29,10 @@ RSpec.describe RequestItemComponent, type: :component do
     end
   end
 
-  context "when DISABLE_REQUESTING is `false`" do
+  context "when FOLIO_UPDATE_IN_PROGRESS is `false`" do
     it "renders the request button" do
       allow(ENV).to receive(:[]).and_call_original
-      allow(ENV).to receive(:[]).with("DISABLE_REQUESTING").and_return("false")
+      allow(ENV).to receive(:[]).with("FOLIO_UPDATE_IN_PROGRESS").and_return("false")
 
       render_inline(described_class.new(document: document))
 
@@ -40,10 +40,10 @@ RSpec.describe RequestItemComponent, type: :component do
     end
   end
 
-  context "when DISABLE_REQUESTING is defined without a value" do
+  context "when FOLIO_UPDATE_IN_PROGRESS is defined without a value" do
     it "renders the request button" do
       allow(ENV).to receive(:[]).and_call_original
-      allow(ENV).to receive(:[]).with("DISABLE_REQUESTING").and_return("")
+      allow(ENV).to receive(:[]).with("FOLIO_UPDATE_IN_PROGRESS").and_return("")
 
       render_inline(described_class.new(document: document))
 
@@ -51,7 +51,7 @@ RSpec.describe RequestItemComponent, type: :component do
     end
   end
 
-  context "when DISABLE_REQUESTING is not defined" do
+  context "when FOLIO_UPDATE_IN_PROGRESS is not defined" do
     it "renders the request button" do
       render_inline(described_class.new(document: document))
 

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -7,19 +7,10 @@ RSpec.describe "Account" do
     sign_in user
   end
 
-  context "when DISABLE_REQUESTING is `true`" do
+  context "when FOLIO_UPDATE_IN_PROGRESS is `true`" do
     it "does not render the request button" do
-      WebMock.stub_request(:get, /catservices.test\/catalogue-services\/folio\/request\/(.*)/)
-        .with(
-          headers: {
-            "Accept" => "*/*",
-            "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
-          }
-        )
-        .to_return(status: 200, body: monograph_details_response, headers: {})
-
       allow(ENV).to receive(:[]).and_call_original
-      allow(ENV).to receive(:[]).with("DISABLE_REQUESTING").and_return("true")
+      allow(ENV).to receive(:[]).with("FOLIO_UPDATE_IN_PROGRESS").and_return("true")
 
       visit root_path
 
@@ -29,10 +20,10 @@ RSpec.describe "Account" do
     end
   end
 
-  context "when DISABLE_REQUESTING is `false`" do
+  context "when FOLIO_UPDATE_IN_PROGRESS is `false`" do
     it "renders the request button" do
       allow(ENV).to receive(:[]).and_call_original
-      allow(ENV).to receive(:[]).with("DISABLE_REQUESTING").and_return("false")
+      allow(ENV).to receive(:[]).with("FOLIO_UPDATE_IN_PROGRESS").and_return("false")
 
       visit root_path
 
@@ -42,40 +33,21 @@ RSpec.describe "Account" do
     end
   end
 
-  context "when DISABLE_REQUESTING is defined without a value" do
+  context "when FOLIO_UPDATE_IN_PROGRESS is defined without a value" do
     it "renders the request button" do
-      WebMock.stub_request(:get, /catservices.test\/catalogue-services\/folio\/request\/(.*)/)
-        .with(
-          headers: {
-            "Accept" => "*/*",
-            "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
-          }
-        )
-        .to_return(status: 200, body: monograph_details_response, headers: {})
-
       allow(ENV).to receive(:[]).and_call_original
-      allow(ENV).to receive(:[]).with("DISABLE_REQUESTING").and_return(nil)
+      allow(ENV).to receive(:[]).with("FOLIO_UPDATE_IN_PROGRESS").and_return(nil)
 
       visit root_path
 
       click_link("Test User")
 
-      expect(ENV["DISABLE_REQUESTING"]).to be_nil
       expect(page).to have_link I18n.t("account.requests.menu"), href: account_requests_path
     end
   end
 
-  context "when DISABLE_REQUESTING is not defined" do
+  context "when FOLIO_UPDATE_IN_PROGRESS is not defined" do
     it "renders the request button" do
-      WebMock.stub_request(:get, /catservices.test\/catalogue-services\/folio\/request\/(.*)/)
-        .with(
-          headers: {
-            "Accept" => "*/*",
-            "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
-          }
-        )
-        .to_return(status: 200, body: monograph_details_response, headers: {})
-
       visit root_path
 
       click_link("Test User")

--- a/spec/system/nav_actions_spec.rb
+++ b/spec/system/nav_actions_spec.rb
@@ -10,4 +10,45 @@ RSpec.describe "Navigation actions" do
 
     expect(page).not_to have_text("History")
   end
+
+  context "when FOLIO_UPDATE_IN_PROGRESS is `true`" do
+    it "does not render the request button" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("FOLIO_UPDATE_IN_PROGRESS").and_return("true")
+
+      visit root_path
+
+      expect(page).not_to have_link I18n.t("blacklight.header_links.login"), href: new_user_session_path
+    end
+  end
+
+  context "when FOLIO_UPDATE_IN_PROGRESS is `false`" do
+    it "renders the request button" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("FOLIO_UPDATE_IN_PROGRESS").and_return("false")
+
+      visit root_path
+
+      expect(page).to have_link I18n.t("blacklight.header_links.login"), href: new_user_session_path
+    end
+  end
+
+  context "when FOLIO_UPDATE_IN_PROGRESS is defined without a value" do
+    it "renders the request button" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("FOLIO_UPDATE_IN_PROGRESS").and_return(nil)
+
+      visit root_path
+
+      expect(page).to have_link I18n.t("blacklight.header_links.login"), href: new_user_session_path
+    end
+  end
+
+  context "when FOLIO_UPDATE_IN_PROGRESS is not defined" do
+    it "renders the request button" do
+      visit root_path
+
+      expect(page).to have_link I18n.t("blacklight.header_links.login"), href: new_user_session_path
+    end
+  end
 end


### PR DESCRIPTION
Disables login during FOLIO updates. Also refactored the previous changes to disable requesting to all be under the same flag.