### PR TITLE
fix: fix editing of user details

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -29,7 +29,7 @@ class AccountController < ApplicationController
   def profile_update
     # Since this is not a database backed model, we need to create a new instance using the
     # current details as a base and then assign the updated attributes to it.
-    @user_details = UserDetails.new(@current_details.attributes)
+    @user_details = UserDetails.new(@current_details.attributes, @current_details.attributes[:email_2fa])
     @user_details.assign_attributes(profile_update_params[:user_details])
 
     # Pass a validation context to target the specific attribute

--- a/app/models/user_details.rb
+++ b/app/models/user_details.rb
@@ -36,13 +36,13 @@ class UserDetails
 
   def attributes
     {
-      "last_name" => last_name,
-      "first_name" => first_name,
-      "email" => email,
-      "phone" => phone,
-      "mobile_phone" => mobile_phone,
-      "postcode" => postcode,
-      "email_2fa" => email_2fa
+      last_name: last_name,
+      first_name: first_name,
+      email: email,
+      phone: phone,
+      mobile_phone: mobile_phone,
+      postcode: postcode,
+      email_2fa: email_2fa
     }
   end
 

--- a/spec/files/profile/user_details.json
+++ b/spec/files/profile/user_details.json
@@ -1,0 +1,25 @@
+{
+  "users": [
+    {
+      "patronGroup": "dc7c6428-54b2-43bb-9497-ff21cdf545d2",
+      "personal": {
+        "lastName": "Test",
+        "firstName": "Blacklight",
+        "email": "test@example.com",
+        "phone": "0398765432",
+        "mobilePhone": "0412345678",
+        "addresses": [
+          {
+            "addressTypeId": "59450b66-4cbd-48b8-811b-e7736d8d17aa",
+            "postalCode": "2600"
+          }
+        ],
+        "preferredContactTypeId": "002"
+      },
+      "id": "603e26dd-b2d4-4a88-ad9d-406eaec31463",
+      "active": true,
+      "expirationDate": "2026-04-17T10:59:09.688+00:00"
+    }
+  ],
+  "totalRecords": 1
+}

--- a/spec/system/profile_spec.rb
+++ b/spec/system/profile_spec.rb
@@ -1,0 +1,48 @@
+require "system_helper"
+
+RSpec.describe "Profile" do
+  before do
+    sign_in create(:user, :patron, name_given: "Blacklight", name_family: "Test")
+  end
+
+  context "when patron has mobile and landline phone numbers" do
+    before do
+      user_details = IO.read("spec/files/profile/user_details.json")
+      WebMock.stub_request(:get, /catservices.test\/catalogue-services\/folio\/user/)
+        .to_return(status: 200, body: user_details, headers: {"Content-Type" => "application/json"})
+    end
+
+    it "displays both phone numbers" do
+      visit account_profile_url
+
+      expect(page).to have_content("0412345678")
+      expect(page).to have_content("0398765432")
+    end
+
+    describe "deleting a phone number" do
+      before do
+        WebMock.stub_request(:post, /catservices.test\/catalogue-services\/folio\/user\/updateDetails/)
+          .to_return(body: '{"status":"OK"}')
+      end
+
+      it "deletes a single number without error" do
+        visit account_profile_url
+
+        click_link "Change my phone number"
+
+        expect(page).to have_content("Update your phone number")
+        expect(page).to have_content("Current phone number")
+        expect(page).to have_content("0398765432")
+
+        fill_in "user_details_phone", with: ""
+
+        click_button "Update"
+
+        expect(page).not_to have_content(I18n.t("account.settings.update.errors.any_phone"))
+
+        # validate page has redirected back to profile page
+        expect(page).to have_content("Your Profile")
+      end
+    end
+  end
+end


### PR DESCRIPTION
I introduced an error with editing the user attributes when I added the email 2FA attribute to the `UserDetails` model that caused the object not to be initialised correctly when passed a hash of attributes.