### PR TITLE
Revert "Update env GLOBAL_MESSAGE_URL"

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -53,7 +53,7 @@ EDS_CACHE_DIR=tmp/cache
 EBSCO_SEARCH_URL="define EBSCO_SEARCH_URL"
 FINDING_AIDS_SEARCH_URL="define FINDING_AIDS_SEARCH_URL"
 
-GLOBAL_MESSAGE_URL=https://www.library.gov.au/catalogue-message
+GLOBAL_MESSAGE_URL="define GLOBAL_MESSAGE_URL"
 
 NATIONAL_LIBRARY_CARD_URL="https://www.library.gov.au/research/join-library"
 ASK_LIBRARIAN_URL=https://www.library.gov.au/services/ask-librarian

--- a/.env.staging
+++ b/.env.staging
@@ -50,7 +50,7 @@ EDS_CACHE_DIR=tmp/cache
 EBSCO_SEARCH_URL="define EBSCO_SEARCH_URL"
 FINDING_AIDS_SEARCH_URL="define FINDING_AIDS_SEARCH_URL"
 
-GLOBAL_MESSAGE_URL=https://www.library.gov.au/catalogue-message
+GLOBAL_MESSAGE_URL="define GLOBAL_MESSAGE_URL"
 
 NATIONAL_LIBRARY_CARD_URL="https://www.library.gov.au/research/join-library"
 ASK_LIBRARIAN_URL=https://www.library.gov.au/services/ask-librarian

--- a/.env.test
+++ b/.env.test
@@ -29,7 +29,7 @@ CATALOGUE_SEARCH_URL=http://test.host/catalog.json
 FINDING_AIDS_SEARCH_URL=http://test.host/finding-aids/catalog.json
 EBSCO_SEARCH_URL=https://search.ebscohost.com/login.aspx?authtype=ip,guest&groupid=main&profile=eds&direct=true
 
-GLOBAL_MESSAGE_URL=https://www.library.gov.au/catalogue-message
+GLOBAL_MESSAGE_URL=http://test.nla.gov.au/catalogue-message/1234
 
 NATIONAL_LIBRARY_CARD_URL="https://www.library.gov.au/research/join-library"
 ASK_LIBRARIAN_URL=https://www.library.gov.au/services/ask-librarian


### PR DESCRIPTION
Reverts nla/nla-blacklight#1161

having the env contain the url seems to break automated testing jobs.