### PR TITLE
CTPL-348: fix 'clear all bookmarks' button leading to error page

### DIFF
--- a/app/views/bookmarks/_clear_bookmarks_widget.html.erb
+++ b/app/views/bookmarks/_clear_bookmarks_widget.html.erb
@@ -1,0 +1,8 @@
+<%= button_to t('blacklight.bookmarks.clear.action_title'), clear_bookmarks_path,
+            method: :delete, # for rails-UJS
+            data: {
+              confirm: t('blacklight.bookmarks.clear.action_confirm'), # for rails-UJS
+              turbo_method: :delete,
+              turbo_confirm: t('blacklight.bookmarks.clear.action_confirm')
+            },
+            class: 'clear-bookmarks btn btn-danger' %>


### PR DESCRIPTION
override default _clear_bookmarks_widget.html.erb, changing `link_to` to `button_to`
