### PR TITLE
Chore/update deps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 
 GIT
   remote: https://github.com/nla/nla-blacklight_common
-  revision: 29415d1882e23b85ab7f92dfbe55f0b76dc9c972
+  revision: 0ff5cb537014d573a03d4e49975932fbe9c383ec
   branch: main
   specs:
     nla-blacklight_common (0.3.6)
@@ -371,7 +371,7 @@ GEM
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
     language_list (1.2.1)
-    language_server-protocol (3.17.0.5)
+    language_server-protocol (3.17.0.6)
     latex-decode (0.4.2)
     library_stdnums (1.6.0)
     lint_roller (1.1.0)
@@ -379,7 +379,7 @@ GEM
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
     logger (1.7.0)
-    lograge (0.14.0)
+    lograge (0.15.0)
       actionpack (>= 4)
       activesupport (>= 4)
       railties (>= 4)
@@ -596,7 +596,7 @@ GEM
       rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.49.1)
+    rubocop-ast (1.50.0)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
     rubocop-capybara (3.0.0)


### PR DESCRIPTION
CVE-2026-38969 unresolved for now (webrick transitive dep via ferrum, no patch available)