### PR TITLE
Revert "chore(deps-dev): bump rubocop-rails from 2.35.5 to 2.36.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,7 +347,7 @@ GEM
       activesupport (>= 7.0.0)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
-    json (2.21.0)
+    json (2.20.0)
     json-jwt (1.17.1)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -608,7 +608,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
-    rubocop-rails (2.36.0)
+    rubocop-rails (2.35.5)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)


### PR DESCRIPTION
Reverts nla/nla-blacklight#1558